### PR TITLE
refactor(Rng): Use fill_bytes more and remove unneeded macro

### DIFF
--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -324,7 +324,7 @@ fn fill_bytes_smoke_testing() {
     let rng = rng!(Default::default());
 
     for _ in 0..1000 {
-        rng.fill_bytes(bytes.as_mut_slice());
+        rng.fill_bytes(&mut bytes);
     }
 
     assert_eq!(


### PR DESCRIPTION
Refactored out custom implementations and simplified the macros so to make use of the `fill_bytes` method. Also changed `fill_bytes` to not incur some overhead with mutable references, so now that it isn't a perf regression to make use of it in hot-paths, made sense to simplify things further.