### PR TITLE
feat(Entropy): Make generate_entropy more flexible with output

### DIFF
--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -1,14 +1,28 @@
 use crate::{thread, DefaultHasher, Hash, Hasher, Instant};
 
-/// Generates a random number from some quick sources
-/// of entropy. Always a non-zero and odd value being returned.
+/// Generates a random buffer from some quick sources
+/// of entropy. Always a non-zero being returned.
 #[inline]
-pub(crate) fn generate_entropy() -> u64 {
+pub(crate) fn generate_entropy<const SIZE: usize>() -> [u8; SIZE] {
     let mut hasher = DefaultHasher::new();
     Instant::now().hash(&mut hasher);
     thread::current().id().hash(&mut hasher);
-    let hash = hasher.finish();
-    (hash << 1) | 1
+
+    let mut bytes = [0u8; SIZE];
+
+    let mut buffer = bytes.as_mut();
+    let mut length = buffer.len();
+
+    while length > 0 {
+        length.hash(&mut hasher);
+        let output = hasher.finish().to_ne_bytes();
+        let fill = output.len().min(length);
+        buffer[..fill].copy_from_slice(&output[..fill]);
+        buffer = &mut buffer[fill..];
+        length -= fill;
+    }
+
+    bytes
 }
 
 #[cfg(test)]
@@ -17,16 +31,32 @@ mod tests {
 
     #[test]
     fn entropy_source() {
-        let result = generate_entropy();
+        let result = generate_entropy::<{ core::mem::size_of::<u64>() }>();
 
         assert_ne!(
-            &result, &0,
+            &u64::from_be_bytes(result),
+            &0,
             "generated entropy should always be a non-zero value"
         );
-        assert_eq!(
-            result % 2,
-            1,
-            "generated entropy should always be an odd value"
+    }
+
+    #[test]
+    fn large_entropy_source() {
+        let result = generate_entropy::<{ core::mem::size_of::<u128>() }>();
+
+        let split = core::mem::size_of::<u64>();
+
+        let mut part1 = [0u8; 8];
+        part1.copy_from_slice(&result[..split]);
+        let part1 = u64::from_be_bytes(part1);
+
+        let mut part2 = [0u8; 8];
+        part2.copy_from_slice(&result[split..]);
+        let part2 = u64::from_be_bytes(part2);
+
+        assert_ne!(
+            part1, part2,
+            "internal hasher should not output the same values to fill out the generated buffer"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ use std::time::Instant;
 #[cfg(feature = "atomic")]
 use std::sync::atomic::{AtomicU64, Ordering};
 
+#[macro_use]
+mod methods;
+
 mod entropy;
 mod internal;
 mod source;
@@ -72,88 +75,6 @@ use crate::{entropy::generate_entropy, source::WyRand};
 #[derive(PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Rng<S: State + Debug>(WyRand<S>);
-
-macro_rules! range_int {
-    ($value:tt, $unsigned:tt, $source:ident, $modulus:ident, $doc:tt) => {
-        #[doc = $doc]
-        ///
-        /// Panics if the range is empty.
-        #[inline]
-        pub fn $value(&self, bounds: impl RangeBounds<$value>) -> $value {
-            let lower = match bounds.start_bound() {
-                Bound::Included(lower) => *lower,
-                Bound::Excluded(lower) => lower
-                    .checked_add(1)
-                    .unwrap_or_else(|| panic!("Lower bound value overflowed")),
-                Bound::Unbounded => $value::MIN,
-            };
-            let upper = match bounds.end_bound() {
-                Bound::Included(upper) => *upper,
-                Bound::Excluded(upper) => upper
-                    .checked_sub(1)
-                    .unwrap_or_else(|| panic!("Upper bound value overflowed")),
-                Bound::Unbounded => $value::MAX,
-            };
-
-            assert!(lower <= upper, "Range should not be zero sized or invalid");
-
-            match (lower, upper) {
-                ($value::MIN, $value::MAX) => self.$source(),
-                (_, _) => {
-                    let range = upper.wrapping_sub(lower).wrapping_add(1);
-                    lower.wrapping_add(self.$modulus(range as $unsigned) as $value)
-                }
-            }
-        }
-    };
-}
-
-macro_rules! modulus_int {
-    ($name:ident, $value:tt, $bigger:tt, $source:ident) => {
-        #[inline]
-        fn $name(&self, range: $value) -> $value {
-            const BITS: $bigger = $value::BITS as $bigger;
-
-            let mut generated = self.$source();
-            let mut high = (generated as $bigger).wrapping_mul(range as $bigger);
-            let mut low = high as $value;
-            if low < range {
-                let threshold = range.wrapping_neg() % range;
-                while low < threshold {
-                    generated = self.$source();
-                    high = (generated as $bigger).wrapping_mul(range as $bigger);
-                    low = high as $value;
-                }
-            }
-            (high >> BITS) as $value
-        }
-    };
-}
-
-macro_rules! rand_int {
-    ($func:ident, $int:ty, $doc:tt) => {
-        #[doc = $doc]
-        #[inline]
-        pub fn $func(&self) -> $int {
-            const SIZE: usize = core::mem::size_of::<$int>();
-            let mut bytes = [0u8; SIZE];
-            self.fill_bytes(&mut bytes);
-            <$int>::from_le_bytes(bytes)
-        }
-    };
-}
-
-macro_rules! rand_characters {
-    ($func:ident, $chars:expr, $doc:tt) => {
-        #[doc = $doc]
-        #[inline]
-        pub fn $func(&self) -> char {
-            const CHARS: &[u8] = $chars;
-
-            self.sample(CHARS).map(|&value| value as char).unwrap()
-        }
-    };
-}
 
 /// Initialises an `Rng` instance with a `CellState`. Not thread safe.
 /// Can be used with and without a seed value. If invoked without
@@ -858,7 +779,9 @@ impl<S: State + Debug> Debug for Rng<S> {
 }
 
 thread_local! {
-    static RNG: Rc<Rng<CellState>> = Rc::new(Rng(WyRand::<CellState>::with_seed(generate_entropy())));
+    static RNG: Rc<Rng<CellState>> = Rc::new(Rng(WyRand::<CellState>::with_seed(
+        u64::from_be_bytes(generate_entropy::<{ core::mem::size_of::<u64>() }>()),
+    )));
 }
 
 /// Computes `(a * b) >> 128`. Adapted from: https://stackoverflow.com/a/28904636

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -1,0 +1,81 @@
+macro_rules! range_int {
+    ($value:tt, $unsigned:tt, $source:ident, $modulus:ident, $doc:tt) => {
+        #[doc = $doc]
+        ///
+        /// Panics if the range is empty.
+        #[inline]
+        pub fn $value(&self, bounds: impl RangeBounds<$value>) -> $value {
+            let lower = match bounds.start_bound() {
+                Bound::Included(lower) => *lower,
+                Bound::Excluded(lower) => lower
+                    .checked_add(1)
+                    .unwrap_or_else(|| panic!("Lower bound value overflowed")),
+                Bound::Unbounded => $value::MIN,
+            };
+            let upper = match bounds.end_bound() {
+                Bound::Included(upper) => *upper,
+                Bound::Excluded(upper) => upper
+                    .checked_sub(1)
+                    .unwrap_or_else(|| panic!("Upper bound value overflowed")),
+                Bound::Unbounded => $value::MAX,
+            };
+
+            assert!(lower <= upper, "Range should not be zero sized or invalid");
+
+            match (lower, upper) {
+                ($value::MIN, $value::MAX) => self.$source(),
+                (_, _) => {
+                    let range = upper.wrapping_sub(lower).wrapping_add(1);
+                    lower.wrapping_add(self.$modulus(range as $unsigned) as $value)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! modulus_int {
+    ($name:ident, $value:tt, $bigger:tt, $source:ident) => {
+        #[inline]
+        fn $name(&self, range: $value) -> $value {
+            const BITS: $bigger = $value::BITS as $bigger;
+
+            let mut generated = self.$source();
+            let mut high = (generated as $bigger).wrapping_mul(range as $bigger);
+            let mut low = high as $value;
+            if low < range {
+                let threshold = range.wrapping_neg() % range;
+                while low < threshold {
+                    generated = self.$source();
+                    high = (generated as $bigger).wrapping_mul(range as $bigger);
+                    low = high as $value;
+                }
+            }
+            (high >> BITS) as $value
+        }
+    };
+}
+
+macro_rules! rand_int {
+    ($func:ident, $int:ty, $doc:tt) => {
+        #[doc = $doc]
+        #[inline]
+        pub fn $func(&self) -> $int {
+            const SIZE: usize = core::mem::size_of::<$int>();
+            let mut bytes = [0u8; SIZE];
+            self.fill_bytes(&mut bytes);
+            <$int>::from_le_bytes(bytes)
+        }
+    };
+}
+
+macro_rules! rand_characters {
+    ($func:ident, $chars:expr, $doc:tt) => {
+        #[doc = $doc]
+        #[inline]
+        pub fn $func(&self) -> char {
+            const CHARS: &[u8] = $chars;
+
+            self.sample(CHARS).map(|&value| value as char).unwrap()
+        }
+    };
+}


### PR DESCRIPTION
Some additional clean up as well as extending `generate_entropy` to be more flexible in providing arbitrary lengths of random data. This should unblock further work for secure RNGs that need to be seeded with bigger states than just `u64`.