### PR TITLE
feat(Rng): Implement serialize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ wasm-bindgen-test = "0.3"
 
 [dependencies]
 rand_core = { version = "0.6", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+serde_json = "1.0"
 
 [[bench]]
 name = "rand_bench"
@@ -31,6 +33,7 @@ harness = false
 [features]
 atomic = []
 rand = ["dep:rand_core"]
+serialize = ["dep:serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -3,6 +3,9 @@ use crate::{Cell, Debug};
 #[cfg(feature = "atomic")]
 use crate::{AtomicU64, Ordering};
 
+#[cfg(feature = "serialize")]
+use crate::{Deserialize, Serialize};
+
 /// Trait for implementing [`State`] to be used in a `Rng`.
 ///
 /// Those implementing [`State`] should also ensure to implement
@@ -23,6 +26,7 @@ pub trait State {
 /// Non-[`Send`] and [`Sync`] state for `Rng`. Stores the current
 /// state of the PRNG in a [`Cell`].
 #[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub struct CellState(Cell<u64>);
 
@@ -75,6 +79,7 @@ impl Debug for CellState {
 /// let res2 = thread_02.join();
 /// ```
 #[cfg(feature = "atomic")]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(docsrs, doc(cfg(feature = "atomic")))]
 #[repr(transparent)]
 pub struct AtomicState(AtomicU64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 //!   to provide a thread-safe variation of [`Rng`].
 //! * `rand` - Provides [`RandCompat`], which implements [`RngCore`] and [`SeedableRng`]
 //!   so to allow for compatibility with `rand` ecosystem of crates
+//! * `serialize` - Enables [`Serialize`] and [`Deserialize`] derives on [`Rng`].
 #![warn(missing_docs, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
@@ -71,6 +72,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "rand")]
 use rand_core::{RngCore, SeedableRng};
 
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
+
 #[macro_use]
 mod methods;
 
@@ -83,6 +87,7 @@ use crate::{entropy::generate_entropy, source::WyRand};
 
 /// A Random Number generator, powered by the `WyRand` algorithm.
 #[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub struct Rng<S: State + Debug>(WyRand<S>);
 
@@ -931,5 +936,15 @@ mod tests {
             "Should receive expect random u64 output, got {} instead",
             result
         );
+    }
+
+    #[cfg(feature = "serialize")]
+    #[test]
+    fn serialize_rng() {
+        let rng = rng!(12345);
+
+        let json = serde_json::to_string(&rng).unwrap();
+
+        assert_eq!(json, "{\"state\":24691}", "Serialized output not as expected");
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -3,8 +3,12 @@ use crate::{
     Debug,
 };
 
+#[cfg(feature = "serialize")]
+use crate::{Deserialize, Serialize};
+
 /// A Wyrand Random Number Generator
 #[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub(crate) struct WyRand<S: Debug + State = CellState> {
     state: S,


### PR DESCRIPTION
Allow for the `Rng` state to be serialized/deserialized, with the intent of being able to save/reload a state directly without manual code.