### PR TITLE
feat(Entropy): Better quality entropy sources with fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,15 @@ resolver = "2"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = "0.1"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 wasm-bindgen-test = "0.3"
 
 [dependencies]
+getrandom = { version = "0.2" }
 rand_core = { version = "0.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 


### PR DESCRIPTION
Provide a better source of high quality entropy, for seeding the user space RNGs into as random state as possible. The low quality fallback remains to at least try to provide some sort of entropy if OS/hardware fails to provide, so some robustness with the library remains. If no high quality source, at least there is some source available to prevent the application panicking.