### PR TITLE
feat(RandBorrowed): Provide borrowed interface for rand compatibility

### DIFF
--- a/src/compatibility.rs
+++ b/src/compatibility.rs
@@ -1,0 +1,150 @@
+use crate::{TurboCore, RngCore, Rng};
+
+#[cfg(feature = "secure")]
+use crate::SecureRng;
+
+#[cfg(feature = "atomic")]
+use crate::AtomicRng;
+
+/// A wrapper struct around [`TurboCore`] to allow implementing
+/// [`RngCore`] trait in a compatible manner.
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[derive(PartialEq, Eq)]
+#[repr(transparent)]
+pub struct RandCompat<T: TurboCore + Default>(T);
+
+impl<T: TurboCore + Default> RandCompat<T> {
+    /// Creates a new [`RandCompat`] with a randomised seed.
+    ///
+    /// # Example
+    /// ```
+    /// use turborand::*;
+    /// use rand_core::RngCore;
+    ///
+    /// let mut rng = RandCompat::<Rng>::new();
+    /// let mut buffer = [0u8; 32];
+    ///
+    /// rng.fill_bytes(&mut buffer);
+    ///
+    /// assert_ne!(&buffer, &[0u8; 32]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self(T::default())
+    }
+}
+
+impl<T: TurboCore + Default> Default for RandCompat<T> {
+    /// Initialises a default instance of [`RandCompat`]. Warning, the default is
+    /// seeded with a randomly generated state, so this is **not** deterministic.
+    ///
+    /// # Example
+    /// ```
+    /// use turborand::*;
+    /// use rand_core::RngCore;
+    ///
+    /// let mut rng1 = RandCompat::<Rng>::default();
+    /// let mut rng2 = RandCompat::<Rng>::default();
+    ///
+    /// assert_ne!(rng1.next_u64(), rng2.next_u64());
+    /// ```
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: TurboCore + Default> RngCore for RandCompat<T> {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.0.gen_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        self.0.gen_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest);
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.0.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl<T: TurboCore + Default> From<T> for RandCompat<T> {
+    #[inline]
+    fn from(rng: T) -> Self {
+        Self(rng)
+    }
+}
+
+impl From<RandCompat<Rng>> for Rng {
+    #[inline]
+    fn from(rand: RandCompat<Rng>) -> Self {
+        rand.0
+    }
+}
+
+#[cfg(feature = "atomic")]
+impl From<RandCompat<AtomicRng>> for AtomicRng {
+    #[inline]
+    fn from(rand: RandCompat<AtomicRng>) -> Self {
+        rand.0
+    }
+}
+
+#[cfg(feature = "secure")]
+impl From<RandCompat<SecureRng>> for SecureRng {
+    #[inline]
+    fn from(rand: RandCompat<SecureRng>) -> Self {
+        rand.0
+    }
+}
+
+/// A wrapper struct around a borrowed [`TurboCore`] instance to allow 
+/// implementing [`RngCore`] trait in a compatible manner. Uses a mutable
+/// reference to gain exclusive control over the [`TurboCore`] instance.
+/// [`RngCore`] uses `&mut self` for its methods, so [`RandBorrowed`] should
+/// impose the same requirements onto [`TurboCore`] in needing a `&mut`
+/// reference.
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[derive(PartialEq, Eq)]
+#[repr(transparent)]
+pub struct RandBorrowed<'a, T: TurboCore + Default>(&'a mut T);
+
+impl<'a, T: TurboCore + Default> From<&'a mut T> for RandBorrowed<'a, T> {
+    #[inline]
+    fn from(rng: &'a mut T) -> Self {
+        Self(rng)
+    }
+}
+
+impl<'a, T: TurboCore + Default> RngCore for RandBorrowed<'a, T> {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.0.gen_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        self.0.gen_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest);
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.0.fill_bytes(dest);
+        Ok(())
+    }
+}

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -217,7 +217,7 @@ mod tests {
     fn rand_compatibility() {
         use rand_core::RngCore;
 
-        use crate::RandCompat;
+        use crate::{RandCompat, RandBorrowed};
 
         fn get_rand_num<R: RngCore>(rng: &mut R) -> u64 {
             rng.next_u64()
@@ -226,6 +226,18 @@ mod tests {
         let rng = rng!(Default::default());
 
         let mut rand = RandCompat::from(rng);
+
+        let result = get_rand_num(&mut rand);
+
+        assert_eq!(
+            result, 14_839_104_130_206_199_084,
+            "Should receive expect random u64 output, got {} instead",
+            result
+        );
+
+        let mut rng = rng!(Default::default());
+
+        let mut rand = RandBorrowed::from(&mut rng);
 
         let result = get_rand_num(&mut rand);
 


### PR DESCRIPTION
Whereas `RandCompat` tries to own a `TurboCore` instance, `RandBorrowed` is implemented to provide an interface that instead borrows a `TurboCore` instance to provide `rand` compatibility. This should provide an easier way for `bevy_turborand` to provide a compatibility shim for component/resource types that own the rng instance, but can expose a borrowed interface for `rand` crates to make use of instead of needing to clone the inner `TurboCore` instance.