### PR TITLE
perf(SecureRng): Alignment & Vector optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 wasm-bindgen-test = "0.3"
 
 [dependencies]
+bytemuck = { version = "1", features = ["min_const_generics"], optional = true }
 getrandom = { version = "0.2" }
 rand_core = { version = "0.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -36,7 +37,7 @@ harness = false
 
 [features]
 atomic = []
-secure = []
+secure = ["dep:bytemuck"]
 rand = ["dep:rand_core"]
 serialize = ["dep:serde"]
 

--- a/src/source/chacha.rs
+++ b/src/source/chacha.rs
@@ -39,18 +39,12 @@ impl ChaCha8 {
     }
 
     #[inline]
-    fn generate(&self) -> [u8; 64] {
+    fn generate(&self) -> [u32; 16] {
         // SAFETY: Pointer is kept here only for as long as the read happens. The memory
         // being read will always be initialised, therefore this is safe.
         let new_state = unsafe { calculate_block::<4>(self.state.get().read()) };
 
-        let mut output = [0_u8; 64];
-
-        new_state
-            .iter()
-            .flat_map(|num| num.to_ne_bytes())
-            .zip(output.iter_mut())
-            .for_each(|(val, slot)| *slot = val);
+        let output = new_state;
 
         increment_counter(new_state).map_or_else(
             || {
@@ -140,7 +134,7 @@ mod tests {
                 let source = ChaCha8::with_seed($seed);
 
                 let expected_output: [u8; 64] = $output1;
-                let output = source.generate();
+                let output = source.rand::<64>();
 
                 assert_eq!(&output, &expected_output);
             }


### PR DESCRIPTION
Make ChaCha8 struct smaller with Vector backed EntropyBuffer & pass better aligned data around for extra perf gains.

Optimisations takes clone time from 237ns to 73ns, fill_bytes with 24 byte array from 75ns  to 29ns, and gen_u32 from 15ns to 10ns. Nice and speedy, without needing SIMD just yet for optimisation.