### PR TITLE
refactor(TurboCore): Make trait object safe, split out GenCore trait

### DIFF
--- a/src/compatibility.rs
+++ b/src/compatibility.rs
@@ -1,6 +1,6 @@
 //! Compatibility shims for the `rand` crate ecosystem.
 
-use crate::{traits::TurboCore, RngCore};
+use crate::{traits::{TurboCore, GenCore}, RngCore};
 
 #[cfg(feature = "wyrand")]
 use crate::rng::Rng;
@@ -16,9 +16,9 @@ use crate::rng::AtomicRng;
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 #[derive(PartialEq, Eq)]
 #[repr(transparent)]
-pub struct RandCompat<T: TurboCore + Default>(T);
+pub struct RandCompat<T: TurboCore + GenCore + Default>(T);
 
-impl<T: TurboCore + Default> RandCompat<T> {
+impl<T: TurboCore + GenCore + Default> RandCompat<T> {
     /// Creates a new [`RandCompat`] with a randomised seed.
     ///
     /// # Example
@@ -40,7 +40,7 @@ impl<T: TurboCore + Default> RandCompat<T> {
     }
 }
 
-impl<T: TurboCore + Default> Default for RandCompat<T> {
+impl<T: TurboCore + GenCore + Default> Default for RandCompat<T> {
     /// Initialises a default instance of [`RandCompat`]. Warning, the default is
     /// seeded with a randomly generated state, so this is **not** deterministic.
     ///
@@ -60,7 +60,7 @@ impl<T: TurboCore + Default> Default for RandCompat<T> {
     }
 }
 
-impl<T: TurboCore + Default> RngCore for RandCompat<T> {
+impl<T: TurboCore + GenCore + Default> RngCore for RandCompat<T> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.gen_u32()
@@ -83,7 +83,7 @@ impl<T: TurboCore + Default> RngCore for RandCompat<T> {
     }
 }
 
-impl<T: TurboCore + Default> From<T> for RandCompat<T> {
+impl<T: TurboCore + GenCore + Default> From<T> for RandCompat<T> {
     #[inline]
     fn from(rng: T) -> Self {
         Self(rng)
@@ -123,9 +123,9 @@ impl From<RandCompat<SecureRng>> for SecureRng {
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 #[derive(PartialEq, Eq)]
 #[repr(transparent)]
-pub struct RandBorrowed<'a, T: TurboCore + Default>(&'a mut T);
+pub struct RandBorrowed<'a, T: TurboCore + GenCore + Default>(&'a mut T);
 
-impl<'a, T: TurboCore + Default> From<&'a mut T> for RandBorrowed<'a, T> {
+impl<'a, T: TurboCore + GenCore + Default> From<&'a mut T> for RandBorrowed<'a, T> {
     /// Convert a [`TurboCore`] reference into a [`RandBorrowed`] struct,
     /// allowing a borrowed reference to be used with the `rand` crate
     /// ecosystem.
@@ -147,7 +147,7 @@ impl<'a, T: TurboCore + Default> From<&'a mut T> for RandBorrowed<'a, T> {
     }
 }
 
-impl<'a, T: TurboCore + Default> RngCore for RandBorrowed<'a, T> {
+impl<'a, T: TurboCore + GenCore + Default> RngCore for RandBorrowed<'a, T> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         self.0.gen_u32()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,10 @@
 //!
 //! # Features
 //!
-//! The base crate will always export the [`TurboCore`], [`SeededCore`],
-//! [`TurboRand`] and [`SecureCore`] traits, and will do so when set as
-//! `default-features = false` in the Cargo.toml. By default, it will
-//! have `wyrand` feature enabled as the basic PRNG exposed.
+//! The base crate will always export the [`TurboCore`], [`GenCore`],
+//! [`SeededCore`], [`TurboRand`] and [`SecureCore`] traits, and will do
+//! so when set as `default-features = false` in the Cargo.toml. By default,
+//! it will have `wyrand` feature enabled as the basic PRNG exposed.
 //!
 //! * **`wyrand`** - Enables [`rng::Rng`], so to provide a
 //!   basic, non-threadsafe PRNG. Enabled by default.
@@ -109,6 +109,6 @@ pub mod secure_rng;
 mod source;
 mod traits;
 
-pub use traits::{SecureCore, SeededCore, TurboCore, TurboRand};
+pub use traits::{GenCore, SecureCore, SeededCore, TurboCore, TurboRand};
 
 pub mod prelude;

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -3,7 +3,7 @@ macro_rules! gen_int_const {
         #[doc = $doc]
         #[inline]
         fn $func(&self) -> $int {
-            <$int>::from_le_bytes(self.gen::<{ core::mem::size_of::<$int>() }>())
+            <$int>::from_le_bytes(self.gen())
         }
     };
 }

--- a/src/secure_rng.rs
+++ b/src/secure_rng.rs
@@ -1,6 +1,6 @@
 //! A cryptographically secure PRNG (CSPRNG) based on [ChaCha8](https://cr.yp.to/chacha.html).
 use crate::{
-    entropy::generate_entropy, source::chacha::ChaCha8, Rc, SecureCore, SeededCore, TurboCore,
+    entropy::generate_entropy, source::chacha::ChaCha8, Rc, SecureCore, SeededCore, TurboCore, GenCore,
 };
 
 #[cfg(feature = "serialize")]
@@ -30,13 +30,15 @@ impl SecureRng {
 
 impl TurboCore for SecureRng {
     #[inline]
-    fn gen<const SIZE: usize>(&self) -> [u8; SIZE] {
-        self.0.rand::<SIZE>()
-    }
-
-    #[inline]
-    fn fill_bytes<B: AsMut<[u8]>>(&self, buffer: B) {
+    fn fill_bytes(&self, buffer: &mut [u8]) {
         self.0.fill(buffer);
+    }
+}
+
+impl GenCore for SecureRng {
+    #[inline]
+    fn gen<const SIZE: usize>(&self) -> [u8; SIZE] {
+        self.0.rand()
     }
 }
 


### PR DESCRIPTION
Split out `TurboCore` into two traits: `TurboCore` and `GenCore`, refactoring `TurboCore` to be trait object safe. Should allow for some more flexible usage of the traits and implementations.