### PR TITLE
refactor(ChaChaRng): Rename from SecureRng

### DIFF
--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -170,16 +170,16 @@ fn turborand_atomic_benchmark(c: &mut Criterion) {
 }
 
 #[cfg(feature = "chacha")]
-fn turborand_secure_benchmark(c: &mut Criterion) {
-    c.bench_function("SecureRng new", |b| {
-        b.iter(|| black_box(SecureRng::default()));
+fn turborand_chacha_benchmark(c: &mut Criterion) {
+    c.bench_function("ChaChaRng new", |b| {
+        b.iter(|| black_box(ChaChaRng::default()));
     });
-    c.bench_function("SecureRng clone", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng clone", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.clone()));
     });
-    c.bench_function("SecureRng fill_bytes", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng fill_bytes", |b| {
+        let rand = ChaChaRng::default();
 
         let data = [0u8; 24];
 
@@ -189,69 +189,69 @@ fn turborand_secure_benchmark(c: &mut Criterion) {
             criterion::BatchSize::SmallInput,
         )
     });
-    c.bench_function("SecureRng gen_u128", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng gen_u128", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.gen_u128()));
     });
-    c.bench_function("SecureRng gen_u64", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng gen_u64", |b| {
+        let rand = ChaChaRng::default();
 
         b.iter(|| black_box(rand.gen_u64()));
     });
-    c.bench_function("SecureRng gen_u32", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng gen_u32", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.gen_u32()));
     });
-    c.bench_function("SecureRng gen_u16", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng gen_u16", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.gen_u16()));
     });
-    c.bench_function("SecureRng gen_u8", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng gen_u8", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.gen_u8()));
     });
-    c.bench_function("SecureRng bool", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng bool", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.bool()));
     });
-    c.bench_function("SecureRng usize range", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng usize range", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.usize(..20)));
     });
-    c.bench_function("SecureRng isize range", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng isize range", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.isize(-10..10)));
     });
-    c.bench_function("SecureRng u128 bounded range", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng u128 bounded range", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.u128(..20)));
     });
-    c.bench_function("SecureRng i128 bounded range", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng i128 bounded range", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.i128(-20..20)));
     });
-    c.bench_function("SecureRng u64 bounded range", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng u64 bounded range", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.u64(..20)));
     });
-    c.bench_function("SecureRng i32 bounded range", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng i32 bounded range", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.i32(-20..20)));
     });
-    c.bench_function("SecureRng f64", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng f64", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.f64()));
     });
-    c.bench_function("SecureRng f32", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng f32", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.f32()));
     });
-    c.bench_function("SecureRng f64 normalized", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng f64 normalized", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.f64_normalized()));
     });
-    c.bench_function("SecureRng f32 normalized", |b| {
-        let rand = SecureRng::default();
+    c.bench_function("ChaChaRng f32 normalized", |b| {
+        let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.f32_normalized()));
     });
 }
@@ -263,7 +263,7 @@ pub fn benches() {
     #[cfg(feature = "atomic")]
     turborand_atomic_benchmark(&mut criterion);
     #[cfg(feature = "chacha")]
-    turborand_secure_benchmark(&mut criterion);
+    turborand_chacha_benchmark(&mut criterion);
 }
 
 criterion_main!(benches);

--- a/src/chacha_rng.rs
+++ b/src/chacha_rng.rs
@@ -11,10 +11,10 @@ use crate::{Deserialize, Serialize};
 #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(transparent)]
-pub struct SecureRng(ChaCha8);
+pub struct ChaChaRng(ChaCha8);
 
-impl SecureRng {
-    /// Creates a new [`SecureRng`] with a randomised seed.
+impl ChaChaRng {
+    /// Creates a new [`ChaChaRng`] with a randomised seed.
     #[inline]
     #[must_use]
     pub fn new() -> Self {
@@ -28,21 +28,21 @@ impl SecureRng {
     }
 }
 
-impl TurboCore for SecureRng {
+impl TurboCore for ChaChaRng {
     #[inline]
     fn fill_bytes(&self, buffer: &mut [u8]) {
         self.0.fill(buffer);
     }
 }
 
-impl GenCore for SecureRng {
+impl GenCore for ChaChaRng {
     #[inline]
     fn gen<const SIZE: usize>(&self) -> [u8; SIZE] {
         self.0.rand()
     }
 }
 
-impl SeededCore for SecureRng {
+impl SeededCore for ChaChaRng {
     type Seed = [u8; 40];
 
     #[inline]
@@ -57,18 +57,18 @@ impl SeededCore for SecureRng {
     }
 }
 
-impl SecureCore for SecureRng {}
+impl SecureCore for ChaChaRng {}
 
-impl Default for SecureRng {
-    /// Initialises a default instance of [`SecureRng`]. Warning, the default is
+impl Default for ChaChaRng {
+    /// Initialises a default instance of [`ChaChaRng`]. Warning, the default is
     /// seeded with a randomly generated state, so this is **not** deterministic.
     ///
     /// # Example
     /// ```
     /// use turborand::prelude::*;
     ///
-    /// let rng1 = SecureRng::default();
-    /// let rng2 = SecureRng::default();
+    /// let rng1 = ChaChaRng::default();
+    /// let rng2 = ChaChaRng::default();
     ///
     /// assert_ne!(rng1.u64(..), rng2.u64(..));
     /// ```
@@ -78,16 +78,16 @@ impl Default for SecureRng {
     }
 }
 
-impl Clone for SecureRng {
-    /// Clones the [`SecureRng`] by deterministically deriving a new [`SecureRng`] based on the initial
+impl Clone for ChaChaRng {
+    /// Clones the [`ChaChaRng`] by deterministically deriving a new [`ChaChaRng`] based on the initial
     /// seed.
     ///
     /// # Example
     /// ```
     /// use turborand::prelude::*;
     ///
-    /// let rng1 = SecureRng::with_seed([0u8; 40]);
-    /// let rng2 = SecureRng::with_seed([0u8; 40]);
+    /// let rng1 = ChaChaRng::with_seed([0u8; 40]);
+    /// let rng2 = ChaChaRng::with_seed([0u8; 40]);
     ///
     /// // Use the RNGs once each.
     /// rng1.bool();
@@ -104,7 +104,7 @@ impl Clone for SecureRng {
 }
 
 thread_local! {
-    static SECURE: Rc<SecureRng> = Rc::new(SecureRng::with_seed(generate_entropy::<40>()));
+    static SECURE: Rc<ChaChaRng> = Rc::new(ChaChaRng::with_seed(generate_entropy::<40>()));
 }
 
 #[cfg(test)]
@@ -113,9 +113,9 @@ mod tests {
 
     #[test]
     fn no_leaking_debug() {
-        let rng = SecureRng::with_seed([0u8; 40]);
+        let rng = ChaChaRng::with_seed([0u8; 40]);
 
-        assert_eq!(format!("{:?}", rng), "SecureRng(ChaCha8)");
+        assert_eq!(format!("{:?}", rng), "ChaChaRng(ChaCha8)");
     }
 
     #[cfg(feature = "serialize")]
@@ -123,12 +123,12 @@ mod tests {
     fn serde_tokens() {
         use serde_test::{assert_tokens, Token};
 
-        let rng = SecureRng::with_seed([0u8; 40]);
+        let rng = ChaChaRng::with_seed([0u8; 40]);
 
         assert_tokens(
             &rng,
             &[
-                Token::NewtypeStruct { name: "SecureRng" },
+                Token::NewtypeStruct { name: "ChaChaRng" },
                 Token::Struct {
                     name: "ChaCha8",
                     len: 2,
@@ -172,7 +172,7 @@ mod tests {
         assert_tokens(
             &rng,
             &[
-                Token::NewtypeStruct { name: "SecureRng" },
+                Token::NewtypeStruct { name: "ChaChaRng" },
                 Token::Struct {
                     name: "ChaCha8",
                     len: 2,

--- a/src/compatibility.rs
+++ b/src/compatibility.rs
@@ -6,7 +6,7 @@ use crate::{traits::{TurboCore, GenCore}, RngCore};
 use crate::rng::Rng;
 
 #[cfg(feature = "chacha")]
-use crate::secure_rng::SecureRng;
+use crate::chacha_rng::ChaChaRng;
 
 #[cfg(feature = "atomic")]
 use crate::rng::AtomicRng;
@@ -107,9 +107,9 @@ impl From<RandCompat<AtomicRng>> for AtomicRng {
 }
 
 #[cfg(feature = "chacha")]
-impl From<RandCompat<SecureRng>> for SecureRng {
+impl From<RandCompat<ChaChaRng>> for ChaChaRng {
     #[inline]
-    fn from(rand: RandCompat<SecureRng>) -> Self {
+    fn from(rand: RandCompat<ChaChaRng>) -> Self {
         rand.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@
 //! * **`rand`** - Provides [`compatibility::RandCompat`], which implements [`RngCore`]
 //!   so to allow for compatibility with `rand` ecosystem of crates
 //! * **`serialize`** - Enables [`Serialize`] and [`Deserialize`] derives on [`rng::Rng`],
-//!   [`rng::AtomicRng`] and [`secure_rng::SecureRng`], provided they have their
+//!   [`rng::AtomicRng`] and [`chacha_rng::ChaChaRng`], provided they have their
 //!   respective features activated as well.
-//! * **`chacha`** - Enables [`secure_rng::SecureRng`] for providing a more cryptographically
+//! * **`chacha`** - Enables [`chacha_rng::ChaChaRng`] for providing a more cryptographically
 //!   secure source of Rng. Note, this will be slower than [`rng::Rng`] in
 //!   throughput, but will produce much higher quality randomness.
 #![warn(missing_docs, rust_2018_idioms)]
@@ -105,7 +105,7 @@ mod internal;
 pub mod rng;
 #[cfg(feature = "chacha")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
-pub mod secure_rng;
+pub mod chacha_rng;
 mod source;
 mod traits;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,7 +8,7 @@ pub use crate::{internal::*, rng::*};
 
 #[cfg(feature = "chacha")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
-pub use crate::secure_rng::*;
+pub use crate::chacha_rng::*;
 
 #[cfg(feature = "rand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -349,8 +349,8 @@ fn fill_bytes_smoke_testing() {
 #[cfg(feature = "chacha")]
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn secure_rng_smoke_test() {
-    let rand = SecureRng::with_seed([0u8; 40]);
+fn chacha_rng_smoke_test() {
+    let rand = ChaChaRng::with_seed([0u8; 40]);
 
     let value = rand.u64(5..=10);
 
@@ -376,8 +376,8 @@ fn secure_rng_smoke_test() {
 #[cfg(feature = "chacha")]
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn secure_rng_spread_test() {
-    let rng = SecureRng::with_seed([0u8; 40]);
+fn chacha_rng_spread_test() {
+    let rng = ChaChaRng::with_seed([0u8; 40]);
 
     let actual_histogram: BTreeMap<u32, u32> =
         repeat_with(|| rng.u32(1..=10))


### PR DESCRIPTION
Secure has particular connotations in cryptography, which I'm not really confident in being able to make for an RNG that does not necessarily provide constant time methods out of the box. For the purposes of being fast and high-quality entropy source, this is probably fine, but for extra security, you won't be using ChaCha8 anyway and won't mind the extra perf hit from constant-time methods. In the mean time, the struct that is present is renamed to avoid that connotation.