### PR TITLE
refactor(SecureRng): Revamped EntropyBuffer, better serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --all-features
+        run: MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-strict-provenance" cargo miri test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turborand"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "Fast random number generators"

--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -87,7 +87,9 @@ fn turborand_cell_benchmark(c: &mut Criterion) {
 
 #[cfg(feature = "atomic")]
 fn turborand_atomic_benchmark(c: &mut Criterion) {
-    c.bench_function("AtomicRng new", |b| b.iter(|| black_box(AtomicRng::default())));
+    c.bench_function("AtomicRng new", |b| {
+        b.iter(|| black_box(AtomicRng::default()))
+    });
     c.bench_function("AtomicRng clone", |b| {
         let rand = AtomicRng::default();
         b.iter(|| black_box(rand.clone()))

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,73 +1,149 @@
-#[cfg(feature = "serialize")]
-use crate::{Deserialize, Serialize};
+use std::cell::UnsafeCell;
 
-#[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg(feature = "serialize")]
+use crate::{Deserialize, Serialize, SerializeTuple, Visitor};
+
+#[derive(Debug)]
 pub(crate) struct EntropyBuffer<const SIZE: usize> {
-    buffer: Vec<u8>,
-    cursor: usize,
+    buffer: UnsafeCell<[u64; SIZE]>,
+    cursor: UnsafeCell<usize>,
 }
 
 impl<const SIZE: usize> EntropyBuffer<SIZE> {
+    #[cfg(feature = "serialize")]
+    #[inline]
+    fn from_serde(buffer: [u64; SIZE], cursor: usize) -> Self {
+        Self {
+            buffer: UnsafeCell::new(buffer),
+            cursor: UnsafeCell::new(cursor),
+        }
+    }
+
+    /// Create a new [`EntropyBuffer`].
     #[inline]
     #[must_use]
     pub(crate) const fn new() -> Self {
         Self {
-            buffer: Vec::new(),
-            cursor: SIZE,
+            buffer: UnsafeCell::new([0; SIZE]),
+            cursor: UnsafeCell::new(Self::total_bytes()),
         }
     }
 
+    /// Returns the total byte size of the [`EntropyBuffer`], indicating
+    /// how much entropy it can store.
+    #[inline(always)]
+    const fn total_bytes() -> usize {
+        SIZE * core::mem::size_of::<u64>()
+    }
+
+    /// Returns a reference to the buffer.
+    ///
+    /// **WARNING**: No references should live while an update to the buffer
+    /// is made.
+    #[inline]
+    #[must_use]
+    fn get_buffer(&self) -> &[u64; SIZE] {
+        // SAFETY: Data is always initialised and no mutable references
+        // will exist during the liftime of the returned reference. This
+        // can also cause data races if called from different threads, but
+        // EntropyBuffer is not Sync, so this won't happen.
+        unsafe { &*self.buffer.get() }
+    }
+
+    /// Returns the current value of the cursor
+    #[inline]
+    fn get_cursor(&self) -> usize {
+        // SAFETY: Data is always initialised and so the deferenced
+        // pointer will yield a valid cursor value and will never return
+        // a value from some other point in memory. This can also cause data races
+        // if called from different threads, but EntropyBuffer is not Sync, so
+        // this won't happen.
+        unsafe { *self.cursor.get() }
+    }
+
+    /// Updates the cursor with a new value.
+    #[inline]
+    fn update_cursor(&self, cursor: usize) {
+        // SAFETY: Data is writable and does not need to be dropped, and
+        // the pointer is always valid as it will never point to an allocation
+        // nor will it be null. The pointer only lives long enough to perform
+        // the write operation and is not exposed from this point. This can also
+        // cause data races if called from different threads, but EntropyBuffer
+        // is not Sync, so this won't happen. There are no references of the
+        // underlying value ever, only returned/copied values, so this is always
+        // safe to do.
+        unsafe {
+            self.cursor.get().write(cursor);
+        }
+    }
+
+    /// Checks if the stored entropy has been exhausted, by
+    /// seeing if the cursor is the same value as the total
+    /// number of bytes available in the buffer.
     #[inline]
     fn is_empty(&self) -> bool {
-        SIZE == self.cursor
+        Self::total_bytes() == self.get_cursor()
     }
 
+    /// Returns the remaining amount of entropy left in the
+    /// buffer, by subtracting the total amount of bytes in
+    /// the buffer by the value of the cursor. A zero value
+    /// indicates an empty buffer.
     #[inline]
     fn remaining_buffer(&self) -> usize {
-        SIZE - self.cursor
+        Self::total_bytes() - self.get_cursor()
     }
 
+    /// Updates the [`EntropyBuffer`] with a new buffer state, and
+    /// reset the cursor to 0.
+    ///
+    /// **WARNING**: Must not be used while a reference to buffer is
+    /// alive, else this operation will be unsound.
     #[inline]
-    fn reset_buffer<B: AsRef<[u32]>>(&mut self, buffer: B) {
-        let buffer: &[u8] = bytemuck::cast_slice(buffer.as_ref());
-
-        assert!(buffer.len() == SIZE);
-
-        if self.buffer.is_empty() {
-            self.buffer.extend(buffer);
-        } else {
-            self.buffer
-                .iter_mut()
-                .zip(buffer)
-                .for_each(|(slot, &val)| *slot = val);
-        }
-
-        self.cursor = 0;
+    unsafe fn update_entropy(&self, buffer: [u64; SIZE]) {
+        self.buffer.get().write(buffer);
+        self.update_cursor(0);
     }
 
+    /// Fills the incoming mutable byte slice with the available
+    /// stored entropy in the internal buffer. Returns the filled
+    /// length, which can either be the entire length of the mutable
+    /// slice, or the amount filled by the remaining buffer.
     #[inline]
-    fn fill(&mut self, output: &mut [u8]) -> usize {
+    fn fill(&self, output: &mut [u8]) -> usize {
         let length = output.len().min(self.remaining_buffer());
+        let cursor = self.get_cursor();
+        let to = cursor + length;
+        let buffer = bytemuck::cast_slice(self.get_buffer());
 
-        let to = self.cursor + length;
+        output[..length].copy_from_slice(&buffer[cursor..to]);
 
-        output[..length].copy_from_slice(&self.buffer[self.cursor..to]);
-
-        self.cursor = to;
+        self.update_cursor(to);
 
         length
     }
 
+    /// Resets the internal buffer and cursor state, clearing any entropy
+    /// stored.
     #[inline]
-    pub(crate) fn empty_buffer(&mut self) {
-        self.buffer.clear();
-        self.cursor = SIZE;
+    pub(crate) fn empty_buffer(&self) {
+        // SAFETY: No references to buffer exist at this point, so it
+        // is safe to write to the buffer. This can also cause data races
+        // if called from different threads, but EntropyBuffer is not Sync,
+        // so this won't happen.
+        unsafe {
+            self.buffer.get().write([0; SIZE]);
+        }
+        self.update_cursor(Self::total_bytes());
     }
 
+    /// Fills the incoming mutable byte source with available entropy, consuming
+    /// the entropy stored in the buffer until it is exhausted and then pulling in
+    /// more entropy when required to refill the buffer and finish filling the input
+    /// byte slice.
     #[inline]
-    pub(crate) fn fill_bytes_with_source<B: AsMut<[u8]>, R: AsRef<[u32]>, S: Fn() -> R>(
-        &mut self,
+    pub(crate) fn fill_bytes_with_source<B: AsMut<[u8]>, S: Fn() -> [u64; SIZE]>(
+        &self,
         mut output: B,
         source: S,
     ) {
@@ -76,13 +152,18 @@ impl<const SIZE: usize> EntropyBuffer<SIZE> {
 
         while remaining > 0 {
             if self.is_empty() {
-                self.reset_buffer(source());
+                // SAFETY: No references to buffer exist at this point, so it
+                // is safe to write to the buffer. This can also cause data races
+                // if called from different threads, but EntropyBuffer is not Sync,
+                // so this won't happen.
+                unsafe {
+                    self.update_entropy(source());
+                }
             }
 
             let filled = self.fill(output);
 
             output = &mut output[filled..];
-
             remaining -= filled;
         }
     }
@@ -92,6 +173,75 @@ impl<const SIZE: usize> Default for EntropyBuffer<SIZE> {
     #[inline]
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<const SIZE: usize> PartialEq for EntropyBuffer<SIZE> {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_buffer() == other.get_buffer() && self.get_cursor() == other.get_cursor()
+    }
+}
+
+impl<const SIZE: usize> Eq for EntropyBuffer<SIZE> {}
+
+#[cfg(feature = "serialize")]
+impl<const SIZE: usize> Serialize for EntropyBuffer<SIZE> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut buf = serializer.serialize_tuple(SIZE + 1)?;
+
+        // Insert the buffer as tuple elements
+        for val in self.get_buffer().iter() {
+            buf.serialize_element(val)?;
+        }
+
+        // Add the cursor as the last element of the tuple
+        buf.serialize_element(&self.get_cursor())?;
+
+        buf.end()
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl<'de, const SIZE: usize> Deserialize<'de> for EntropyBuffer<SIZE> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct EntropyVisitor<const LENGTH: usize>;
+
+        impl<'de, const LENGTH: usize> Visitor<'de> for EntropyVisitor<LENGTH> {
+            type Value = EntropyBuffer<LENGTH>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "struct EntropyBuffer<{LENGTH}>")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut buf = [0; LENGTH];
+                let mut len: usize = 0;
+
+                for slot in buf.iter_mut() {
+                    *slot = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(len, &self))?;
+                    len += 1;
+                }
+
+                let cursor = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(len, &self))?;
+
+                Ok(EntropyBuffer::from_serde(buf, cursor))
+            }
+        }
+
+        deserializer.deserialize_tuple(SIZE + 1, EntropyVisitor::<SIZE>)
     }
 }
 
@@ -108,9 +258,15 @@ mod tests {
 
     #[test]
     fn fills_byte_slices() {
-        let mut buffer = EntropyBuffer::<8>::new();
+        let buffer = EntropyBuffer::<1>::new();
 
-        buffer.reset_buffer([1, 2]);
+        // SAFETY: No references to the underlying buffer exist, and
+        // the EntropyBuffer instance only exists within the test and
+        // can't be accessed from another thread, so no data races are
+        // possible.
+        unsafe {
+            buffer.update_entropy([(2 << 32) | 1]);
+        }
 
         assert!(!buffer.is_empty());
 
@@ -120,7 +276,7 @@ mod tests {
 
         assert_eq!(&output, &[1, 0, 0, 0]);
         assert_eq!(&filled, &4);
-        assert_eq!(&buffer.cursor, &4);
+        assert_eq!(&buffer.get_cursor(), &4);
         assert!(!buffer.is_empty());
 
         let mut output = [0u8; 6];
@@ -129,10 +285,16 @@ mod tests {
 
         assert_eq!(&output, &[2, 0, 0, 0, 0, 0]);
         assert_eq!(&filled, &4);
-        assert_eq!(&buffer.cursor, &8);
+        assert_eq!(&buffer.get_cursor(), &8);
         assert!(buffer.is_empty());
 
-        buffer.reset_buffer([1, 2]);
+        // SAFETY: No references to the underlying buffer exist, and
+        // the EntropyBuffer instance only exists within the test and
+        // can't be accessed from another thread, so no data races are
+        // possible.
+        unsafe {
+            buffer.update_entropy([(2 << 32) | 1]);
+        }
 
         assert!(!buffer.is_empty());
 
@@ -140,6 +302,56 @@ mod tests {
 
         assert_eq!(&output, &[2, 0, 0, 0, 1, 0]);
         assert_eq!(&filled, &2);
-        assert_eq!(&buffer.cursor, &2);
+        assert_eq!(&buffer.get_cursor(), &2);
+    }
+
+    #[cfg(feature = "serialize")]
+    #[test]
+    fn serde_tokens() {
+        use serde_test::{assert_tokens, Token};
+
+        let buffer = EntropyBuffer::<8>::new();
+
+        assert_tokens(
+            &buffer,
+            &[
+                Token::Tuple { len: 9 },
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(64),
+                Token::TupleEnd,
+            ],
+        );
+
+        // SAFETY: No references to the underlying buffer exist, and
+        // the EntropyBuffer instance only exists within the test and
+        // can't be accessed from another thread, so no data races are
+        // possible.
+        unsafe {
+            buffer.update_entropy([1, 2, 3, 4, 5, 6, 7, 8]);
+        }
+
+        assert_tokens(
+            &buffer,
+            &[
+                Token::Tuple { len: 9 },
+                Token::U64(1),
+                Token::U64(2),
+                Token::U64(3),
+                Token::U64(4),
+                Token::U64(5),
+                Token::U64(6),
+                Token::U64(7),
+                Token::U64(8),
+                Token::U64(0),
+                Token::TupleEnd,
+            ],
+        );
     }
 }

--- a/src/chacha_rng.rs
+++ b/src/chacha_rng.rs
@@ -1,7 +1,10 @@
 //! A cryptographically secure PRNG (CSPRNG) based on [ChaCha8](https://cr.yp.to/chacha.html).
 use crate::{
-    entropy::generate_entropy, source::chacha::ChaCha8, Rc, SecureCore, SeededCore, TurboCore, GenCore,
+    entropy::generate_entropy, source::chacha::ChaCha8, GenCore, Rc, SecureCore, SeededCore,
+    TurboCore,
 };
+
+use crate::source::chacha::utils::AlignedSeed;
 
 #[cfg(feature = "serialize")]
 use crate::{Deserialize, Serialize};
@@ -48,12 +51,12 @@ impl SeededCore for ChaChaRng {
     #[inline]
     #[must_use]
     fn with_seed(seed: Self::Seed) -> Self {
-        Self(ChaCha8::with_seed(seed))
+        Self(ChaCha8::with_seed(AlignedSeed::from(seed)))
     }
 
     #[inline]
     fn reseed(&self, seed: Self::Seed) {
-        self.0.reseed(seed);
+        self.0.reseed(AlignedSeed::from(seed));
     }
 }
 
@@ -104,7 +107,7 @@ impl Clone for ChaChaRng {
 }
 
 thread_local! {
-    static SECURE: Rc<ChaChaRng> = Rc::new(ChaChaRng::with_seed(generate_entropy::<40>()));
+    static SECURE: Rc<ChaChaRng> = Rc::new(ChaChaRng::with_seed(generate_entropy()));
 }
 
 #[cfg(test)]
@@ -153,16 +156,17 @@ mod tests {
                 Token::U32(0),
                 Token::TupleEnd,
                 Token::BorrowedStr("cache"),
-                Token::Struct {
-                    name: "EntropyBuffer",
-                    len: 2,
-                },
-                Token::BorrowedStr("buffer"),
-                Token::Seq { len: Some(0) },
-                Token::SeqEnd,
-                Token::BorrowedStr("cursor"),
+                Token::Tuple { len: 9 },
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
+                Token::U64(0),
                 Token::U64(64),
-                Token::StructEnd,
+                Token::TupleEnd,
                 Token::StructEnd,
             ],
         );
@@ -197,80 +201,17 @@ mod tests {
                 Token::U32(1123945486),
                 Token::TupleEnd,
                 Token::BorrowedStr("cache"),
-                Token::Struct {
-                    name: "EntropyBuffer",
-                    len: 2,
-                },
-                Token::BorrowedStr("buffer"),
-                Token::Seq { len: Some(64) },
-                Token::U8(62),
-                Token::U8(0),
-                Token::U8(239),
-                Token::U8(47),
-                Token::U8(137),
-                Token::U8(95),
-                Token::U8(64),
-                Token::U8(214),
-                Token::U8(127),
-                Token::U8(91),
-                Token::U8(184),
-                Token::U8(232),
-                Token::U8(31),
-                Token::U8(9),
-                Token::U8(165),
-                Token::U8(161),
-                Token::U8(44),
-                Token::U8(132),
-                Token::U8(14),
-                Token::U8(195),
-                Token::U8(206),
-                Token::U8(154),
-                Token::U8(127),
-                Token::U8(59),
-                Token::U8(24),
-                Token::U8(27),
-                Token::U8(225),
-                Token::U8(136),
-                Token::U8(239),
-                Token::U8(113),
-                Token::U8(26),
-                Token::U8(30),
-                Token::U8(152),
-                Token::U8(76),
-                Token::U8(225),
-                Token::U8(114),
-                Token::U8(185),
-                Token::U8(33),
-                Token::U8(111),
-                Token::U8(65),
-                Token::U8(159),
-                Token::U8(68),
-                Token::U8(83),
-                Token::U8(103),
-                Token::U8(69),
-                Token::U8(109),
-                Token::U8(86),
-                Token::U8(25),
-                Token::U8(49),
-                Token::U8(74),
-                Token::U8(66),
-                Token::U8(163),
-                Token::U8(218),
-                Token::U8(134),
-                Token::U8(176),
-                Token::U8(1),
-                Token::U8(56),
-                Token::U8(123),
-                Token::U8(253),
-                Token::U8(184),
-                Token::U8(14),
-                Token::U8(12),
-                Token::U8(254),
-                Token::U8(66),
-                Token::SeqEnd,
-                Token::BorrowedStr("cursor"),
+                Token::Tuple { len: 9 },
+                Token::U64(15438444565445410878),
+                Token::U64(11647726043916688255),
+                Token::U64(4287315583106450476),
+                Token::U64(2169171444139891480),
+                Token::U64(4715024415260232856),
+                Token::U64(1825766843798996127),
+                Token::U64(121745463539026481),
+                Token::U64(4827309107960445752),
                 Token::U64(16),
-                Token::StructEnd,
+                Token::TupleEnd,
                 Token::StructEnd,
             ],
         );

--- a/src/compatibility.rs
+++ b/src/compatibility.rs
@@ -1,6 +1,9 @@
 //! Compatibility shims for the `rand` crate ecosystem.
 
-use crate::{traits::{TurboCore, GenCore}, RngCore};
+use crate::{
+    traits::{GenCore, TurboCore},
+    RngCore,
+};
 
 #[cfg(feature = "wyrand")]
 use crate::rng::Rng;
@@ -114,7 +117,7 @@ impl From<RandCompat<ChaChaRng>> for ChaChaRng {
     }
 }
 
-/// A wrapper struct around a borrowed [`TurboCore`] instance to allow 
+/// A wrapper struct around a borrowed [`TurboCore`] instance to allow
 /// implementing [`RngCore`] trait in a compatible manner. Uses a mutable
 /// reference to gain exclusive control over the [`TurboCore`] instance.
 /// [`RngCore`] uses `&mut self` for its methods, so [`RandBorrowed`] should
@@ -129,16 +132,16 @@ impl<'a, T: TurboCore + GenCore + Default> From<&'a mut T> for RandBorrowed<'a, 
     /// Convert a [`TurboCore`] reference into a [`RandBorrowed`] struct,
     /// allowing a borrowed reference to be used with the `rand` crate
     /// ecosystem.
-    /// 
+    ///
     /// # Example
     /// ```
     /// use turborand::prelude::*;
     /// use rand_core::RngCore;
-    /// 
+    ///
     /// let mut turbo = Rng::with_seed(Default::default());
-    /// 
+    ///
     /// let mut rng = RandBorrowed::from(&mut turbo);
-    /// 
+    ///
     /// assert_eq!(rng.next_u32(), 3791187244);
     /// ```
     #[inline]

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -34,7 +34,6 @@ fn fallback_entropy<B: AsMut<[u8]>>(mut buffer: B) -> Result<(), Error> {
 
 /// Generates a random buffer from some OS/Hardware sources
 /// of entropy. Fallback provided in case OS/Hardware sources fail.
-#[inline]
 pub(crate) fn generate_entropy<const SIZE: usize>() -> [u8; SIZE] {
     let mut bytes = [0u8; SIZE];
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -22,7 +22,7 @@ use crate::Visitor;
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
 pub trait State: Sized {
     /// Seed Associated Type, must be `Sized` and `Default`.
-    type Seed: Sized + Default;
+    type Seed: Sized + Default + Copy;
     /// Initialise a state with a seed value.
     fn with_seed(seed: Self::Seed) -> Self
     where
@@ -31,6 +31,13 @@ pub trait State: Sized {
     fn get(&self) -> Self::Seed;
     /// Set the state with a new value.
     fn set(&self, value: Self::Seed);
+    /// Update the internal state and return the new, resulting value
+    #[inline]
+    fn update<F: Fn(Self::Seed) -> Self::Seed>(&self, updater: F) -> Self::Seed {
+        let new_value = updater(self.get());
+        self.set(new_value);
+        new_value
+    }
 }
 
 /// Non-[`Send`] and [`Sync`] state for `Rng`. Stores the current

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 //!   secure source of Rng. Note, this will be slower than [`rng::Rng`] in
 //!   throughput, but will produce much higher quality randomness.
 #![warn(missing_docs, rust_2018_idioms)]
+#![forbid(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
 
@@ -86,13 +87,16 @@ use serde::{Deserialize, Serialize};
 use serde::de::Visitor;
 
 #[cfg(all(feature = "serialize", feature = "chacha"))]
-use serde::ser::SerializeStruct;
+use serde::ser::{SerializeStruct, SerializeTuple};
 
 #[macro_use]
 mod methods;
 
 #[cfg(feature = "chacha")]
 mod buffer;
+#[cfg(feature = "chacha")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
+pub mod chacha_rng;
 #[cfg(feature = "rand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 pub mod compatibility;
@@ -103,9 +107,6 @@ mod internal;
 #[cfg(any(feature = "wyrand", feature = "atomic"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "wyrand", feature = "atomic"))))]
 pub mod rng;
-#[cfg(feature = "chacha")]
-#[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
-pub mod chacha_rng;
 mod source;
 mod traits;
 

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -62,7 +62,7 @@ macro_rules! trait_float_gen {
         fn $name(&self) -> $value {
             (self.$source() as $value) / (<$int>::MAX as $value)
         }
-    }
+    };
 }
 
 macro_rules! trait_rand_chars {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,8 +1,8 @@
 //! A fast but **not** cryptographically secure PRNG based on [Wyrand](https://github.com/wangyi-fudan/wyhash).
 
 use crate::{
-    entropy::generate_entropy, internal::CellState, source::wyrand::WyRand, Debug, Rc, SeededCore,
-    TurboCore, GenCore,
+    entropy::generate_entropy, internal::CellState, source::wyrand::WyRand, Debug, GenCore, Rc,
+    SeededCore, TurboCore,
 };
 
 #[cfg(feature = "atomic")]

--- a/src/source/wyrand.rs
+++ b/src/source/wyrand.rs
@@ -34,8 +34,9 @@ impl<S: State<Seed = u64> + Debug> WyRand<S> {
 
     #[inline]
     fn generate(&self) -> [u8; core::mem::size_of::<u64>()] {
-        let state = self.state.get().wrapping_add(0xa076_1d64_78bd_642f);
-        self.state.set(state);
+        let state = self
+            .state
+            .update(|value| value.wrapping_add(0xa076_1d64_78bd_642f));
         let t = u128::from(state).wrapping_mul(u128::from(state ^ 0xe703_7ed1_a0b4_28db));
         let ret = (t.wrapping_shr(64) ^ t) as u64;
         ret.to_le_bytes()
@@ -45,7 +46,7 @@ impl<S: State<Seed = u64> + Debug> WyRand<S> {
     #[inline]
     pub(crate) fn rand<const SIZE: usize>(&self) -> [u8; SIZE] {
         let mut output = [0u8; SIZE];
-        
+
         self.fill(&mut output);
 
         output

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -349,9 +349,9 @@ pub trait TurboRand: TurboCore + GenCore {
     fn sample<'a, T>(&self, list: &'a [T]) -> Option<&'a T> {
         match list.len() {
             0 => None,
-            // SOUND: Length already known to be 1, therefore index 0 will yield an item
+            // SAFETY: Length already known to be 1, therefore index 0 will yield an item
             1 => unsafe { Some(list.get_unchecked(0)) },
-            // SOUND: Range is exclusive, so yielded random values will always be a valid index and within bounds
+            // SAFETY: Range is exclusive, so yielded random values will always be a valid index and within bounds
             _ => unsafe { Some(list.get_unchecked(self.usize(..list.len()))) },
         }
     }
@@ -412,7 +412,7 @@ pub trait TurboRand: TurboCore + GenCore {
             // No values in list, therefore return None.
             0 => None,
             // Only a single value in list, therefore sampling will always yield that value.
-            // SOUND: Length already known to be 1, therefore index 0 will yield an item
+            // SAFETY: Length already known to be 1, therefore index 0 will yield an item
             1 => unsafe { Some(list.get_unchecked(0)) },
             // Sample the list, flatten the `Option<&T>` and then check if it passes the
             // weighted chance. Keep repeating until `.find` yields a value.
@@ -698,7 +698,10 @@ mod tests {
     fn seeded_methods() {
         let rng = TestRng::with_seed(5);
 
-        fn test_seeded_methods<T: GenCore + SeededCore>(source: &T) where T: SeededCore<Seed = u8> {
+        fn test_seeded_methods<T: GenCore + SeededCore>(source: &T)
+        where
+            T: SeededCore<Seed = u8>,
+        {
             let values = source.gen();
 
             assert_eq!(&values, &[5, 6, 7]);


### PR DESCRIPTION
Since `bevy_reflect` does not support non-Sync structs, reflection support is blocked for `turborand` as a whole until all that is resolved. For now, repurposing the work to provide some perf improvements for SecureRng number generation (at the slight cost in new/cloning perf), as well as better serialization for EntropyBuffer that works with it now being backed by a const-generic sized array instead of a Vec.