### PR TITLE
refactor(Rng): Make internals private, fix perf regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 /Cargo.lock
 .vscode
+*.data
+*.data.old
+flamegraph.svg

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -20,7 +20,7 @@ use crate::Visitor;
 /// leaking the Rng's state via debug, which could have security
 /// implications if one wishes to obfuscate the Rng's state.
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
-pub trait State: Sized {
+pub(crate) trait State: Sized {
     /// Seed Associated Type, must be `Sized` and `Default`.
     type Seed: Sized + Default + Copy;
     /// Initialise a state with a seed value.
@@ -46,7 +46,7 @@ pub trait State: Sized {
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
 #[repr(transparent)]
-pub struct CellState(Cell<u64>);
+pub(crate) struct CellState(Cell<u64>);
 
 impl State for CellState {
     type Seed = u64;
@@ -98,7 +98,7 @@ impl Debug for CellState {
 #[cfg(feature = "atomic")]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "wyrand", feature = "atomic"))))]
 #[repr(transparent)]
-pub struct AtomicState(AtomicU64);
+pub(crate) struct AtomicState(AtomicU64);
 
 #[cfg(feature = "atomic")]
 impl State for AtomicState {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,7 +4,7 @@ pub use crate::traits::*;
 
 #[cfg(any(feature = "wyrand", feature = "atomic"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "wyrand", feature = "atomic"))))]
-pub use crate::{internal::*, rng::*};
+pub use crate::rng::*;
 
 #[cfg(feature = "chacha")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]

--- a/src/source/wyrand.rs
+++ b/src/source/wyrand.rs
@@ -1,3 +1,5 @@
+use std::iter::repeat_with;
+
 use crate::{
     internal::{CellState, State},
     Debug,
@@ -55,17 +57,14 @@ impl<S: State<Seed = u64> + Debug> WyRand<S> {
     #[inline]
     pub fn fill<B: AsMut<[u8]>>(&self, mut buffer: B) {
         let mut output = buffer.as_mut();
-        let mut remaining = output.len();
+        let remaining = (output.len() as f32 / core::mem::size_of::<u64>() as f32).ceil() as usize;
 
-        while remaining > 0 {
-            let input = self.generate();
+        for input in repeat_with(|| self.generate()).take(remaining) {
             let fill = output.len().min(input.len());
 
             output[..fill].copy_from_slice(&input[..fill]);
 
             output = &mut output[fill..];
-
-            remaining -= fill;
         }
     }
 }


### PR DESCRIPTION
Ensure internals are now private and not leaked via prelude. Also fixing a perf regression for WyRand RNG, which saw severely reduced output for any output greater than 64 bits. Now for u128 integers and the fill_bytes benchmark, seeing perf improvement of 78%.