### PR TITLE
refactor(Clone): Separate forking and cloning behaviours

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turborand"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "Fast random number generators"

--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -8,6 +8,10 @@ fn turborand_cell_benchmark(c: &mut Criterion) {
         let rand = Rng::default();
         b.iter(|| black_box(rand.clone()))
     });
+    c.bench_function("CellRng fork", |b| {
+        let rand = Rng::default();
+        b.iter(|| black_box(rand.fork()))
+    });
     c.bench_function("CellRng fill_bytes", |b| {
         let rand = Rng::default();
 
@@ -94,6 +98,10 @@ fn turborand_atomic_benchmark(c: &mut Criterion) {
         let rand = AtomicRng::default();
         b.iter(|| black_box(rand.clone()))
     });
+    c.bench_function("AtomicRng fork", |b| {
+        let rand = AtomicRng::default();
+        b.iter(|| black_box(rand.fork()))
+    });
     c.bench_function("AtomicRng fill_bytes", |b| {
         let rand = AtomicRng::default();
 
@@ -179,6 +187,10 @@ fn turborand_chacha_benchmark(c: &mut Criterion) {
     c.bench_function("ChaChaRng clone", |b| {
         let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.clone()));
+    });
+    c.bench_function("ChaChaRng fork", |b| {
+        let rand = ChaChaRng::default();
+        b.iter(|| black_box(rand.fork()));
     });
     c.bench_function("ChaChaRng fill_bytes", |b| {
         let rand = ChaChaRng::default();

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -18,15 +18,14 @@ fn fallback_entropy<B: AsMut<[u8]>>(mut buffer: B) -> Result<(), Error> {
     thread::current().id().hash(&mut hasher);
 
     let mut buffer = buffer.as_mut();
-    let mut remaining = buffer.len();
 
-    while remaining > 0 {
-        remaining.hash(&mut hasher);
+    while !buffer.is_empty() {
+        buffer.len().hash(&mut hasher);
         let output = hasher.finish().to_ne_bytes();
-        let fill = output.len().min(remaining);
-        buffer[..fill].copy_from_slice(&output[..fill]);
-        buffer = &mut buffer[fill..];
-        remaining -= fill;
+        let fill = output.len().min(buffer.len());
+        let (target, remaining) = buffer.split_at_mut(fill);
+        target.copy_from_slice(&output[..fill]);
+        buffer = remaining;
     }
 
     Ok(())

--- a/src/internal/buffer.rs
+++ b/src/internal/buffer.rs
@@ -179,6 +179,16 @@ impl<const SIZE: usize> Default for EntropyBuffer<SIZE> {
     }
 }
 
+impl<const SIZE: usize> Clone for EntropyBuffer<SIZE> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            buffer: UnsafeCell::new(*self.get_buffer()),
+            cursor: UnsafeCell::new(self.get_cursor()),
+        }
+    }
+}
+
 impl<const SIZE: usize> PartialEq for EntropyBuffer<SIZE> {
     fn eq(&self, other: &Self) -> bool {
         self.get_buffer() == other.get_buffer() && self.get_cursor() == other.get_cursor()
@@ -294,6 +304,24 @@ mod tests {
         assert_eq!(&output, &[2, 0, 0, 0, 1, 0]);
         assert_eq!(&filled, &2);
         assert_eq!(&buffer.get_cursor(), &2);
+    }
+
+    #[test]
+    fn clone_buffer() {
+        let buffer = EntropyBuffer::<1>::new();
+
+        buffer.update_entropy([(2 << 32) | 1]);
+
+        let mut output = [0u8; 4];
+
+        // Modify the buffer to have a new state.
+        buffer.fill(&mut output);
+
+        // Clone the buffer
+        let cloned = buffer.clone();
+
+        // Check if the cloned buffer has the same state as the original
+        assert_eq!(&buffer, &cloned);
     }
 
     #[cfg(feature = "serialize")]

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -69,6 +69,13 @@ impl Debug for CellState {
     }
 }
 
+impl Clone for CellState {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(Cell::new(self.get()))
+    }
+}
+
 /// [`Send`] and [`Sync`] state for `AtomicRng`. Stores the current
 /// state of the PRNG in a [`AtomicU64`].
 ///
@@ -131,6 +138,14 @@ impl Eq for AtomicState {}
 impl Debug for AtomicState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("AtomicState").finish()
+    }
+}
+
+#[cfg(feature = "atomic")]
+impl Clone for AtomicState {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(AtomicU64::new(self.get()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,6 @@ pub mod rng;
 mod source;
 mod traits;
 
-pub use traits::{GenCore, SecureCore, SeededCore, TurboCore, TurboRand};
+pub use traits::{ForkableCore, GenCore, SecureCore, SeededCore, TurboCore, TurboRand};
 
 pub mod prelude;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,8 +1,8 @@
 //! A fast but **not** cryptographically secure PRNG based on [Wyrand](https://github.com/wangyi-fudan/wyhash).
 
 use crate::{
-    entropy::generate_entropy, internal::state::CellState, source::wyrand::WyRand,
-    ForkableCore, Debug, GenCore, Rc, SeededCore, TurboCore,
+    entropy::generate_entropy, internal::state::CellState, source::wyrand::WyRand, Debug,
+    ForkableCore, GenCore, Rc, SeededCore, TurboCore,
 };
 
 #[cfg(feature = "atomic")]
@@ -162,7 +162,6 @@ impl ForkableCore for AtomicRng {
         Self(WyRand::with_seed(u64::from_le_bytes(self.0.rand())))
     }
 }
-
 
 #[cfg(feature = "atomic")]
 impl TurboCore for AtomicRng {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,8 +1,8 @@
 //! A fast but **not** cryptographically secure PRNG based on [Wyrand](https://github.com/wangyi-fudan/wyhash).
 
 use crate::{
-    entropy::generate_entropy, internal::state::CellState, source::wyrand::WyRand, Debug, GenCore,
-    Rc, SeededCore, TurboCore,
+    entropy::generate_entropy, internal::state::CellState, source::wyrand::WyRand,
+    ForkableCore, Debug, GenCore, Rc, SeededCore, TurboCore,
 };
 
 #[cfg(feature = "atomic")]
@@ -12,7 +12,7 @@ use crate::internal::state::AtomicState;
 use crate::{Deserialize, Serialize};
 
 /// A Random Number generator, powered by the `WyRand` algorithm.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
 #[repr(transparent)]
@@ -23,7 +23,7 @@ impl Rng {
     #[inline]
     #[must_use]
     pub fn new() -> Self {
-        Self(WyRand::with_seed(RNG.with(|rng| rng.gen_u64())))
+        RNG.with(|rng| rng.fork())
     }
 
     /// Reseeds the current thread-local generator.
@@ -81,28 +81,11 @@ impl Default for Rng {
     }
 }
 
-impl Clone for Rng {
-    /// Clones the [`Rng`] by deterministically deriving a new [`Rng`] based on the initial
-    /// seed.
-    ///
-    /// # Example
-    /// ```
-    /// use turborand::prelude::*;
-    ///
-    /// let rng1 = Rng::with_seed(Default::default());
-    /// let rng2 = Rng::with_seed(Default::default());
-    ///
-    /// // Use the RNGs once each.
-    /// rng1.bool();
-    /// rng2.bool();
-    ///
-    /// let cloned1 = rng1.clone();
-    /// let cloned2 = rng2.clone();
-    ///
-    /// assert_eq!(cloned1.u64(..), cloned2.u64(..));
-    /// ```
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
+impl ForkableCore for Rng {
+    #[inline]
+    #[must_use]
+    fn fork(&self) -> Self {
+        Self(WyRand::with_seed(u64::from_le_bytes(self.0.rand())))
     }
 }
 
@@ -170,6 +153,16 @@ impl Clone for AtomicRng {
         Self(self.0.clone())
     }
 }
+
+#[cfg(feature = "atomic")]
+impl ForkableCore for AtomicRng {
+    #[inline]
+    #[must_use]
+    fn fork(&self) -> Self {
+        Self(WyRand::with_seed(u64::from_le_bytes(self.0.rand())))
+    }
+}
+
 
 #[cfg(feature = "atomic")]
 impl TurboCore for AtomicRng {

--- a/src/source/chacha.rs
+++ b/src/source/chacha.rs
@@ -97,8 +97,8 @@ impl ChaCha8 {
 impl Clone for ChaCha8 {
     fn clone(&self) -> Self {
         Self {
-            state: UnsafeCell::new(init_state(self.rand().into())),
-            cache: EntropyBuffer::new(),
+            state: UnsafeCell::new(*self.get_state()),
+            cache: self.cache.clone(),
         }
     }
 }
@@ -221,6 +221,15 @@ mod tests {
         let source = ChaCha8::with_seed([0u8; 40].into());
 
         assert_eq!(format!("{:?}", source), "ChaCha8");
+    }
+
+    #[test]
+    fn clone_chacha_source() {
+        let source = ChaCha8::with_seed([0u8; 40].into());
+
+        let cloned = source.clone();
+
+        assert_eq!(&source, &cloned);
     }
 
     #[test]

--- a/src/source/wyrand.rs
+++ b/src/source/wyrand.rs
@@ -9,7 +9,7 @@ use crate::{
 use crate::{Deserialize, Serialize};
 
 /// A Wyrand Random Number Generator
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub(crate) struct WyRand<S: Debug + State = CellState>
@@ -71,15 +71,6 @@ impl<S: State<Seed = u64> + Debug> WyRand<S> {
     }
 }
 
-impl<S: State<Seed = u64> + Debug> Clone for WyRand<S> {
-    /// Deterministically clones the [`WyRand`] source.
-    fn clone(&self) -> Self {
-        Self {
-            state: S::with_seed(u64::from_le_bytes(self.rand())),
-        }
-    }
-}
-
 impl<S: State<Seed = u64> + Debug> Debug for WyRand<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("WyRand").field(&self.state).finish()
@@ -136,15 +127,15 @@ mod tests {
         let cloned1 = rng1.clone();
         let cloned2 = rng2.clone();
 
-        assert_ne!(
-            &rng1.generate(),
-            &cloned1.generate(),
-            "cloned rngs should not match against the original"
+        assert_eq!(
+            &rng1,
+            &cloned1,
+            "cloned rngs should match against the original"
         );
-        assert_ne!(
-            &rng2.generate(),
-            &cloned2.generate(),
-            "cloned rngs should not match against the original"
+        assert_eq!(
+            &rng2,
+            &cloned2,
+            "cloned rngs should match against the original"
         );
         assert_eq!(
             &cloned1.generate(),

--- a/src/source/wyrand.rs
+++ b/src/source/wyrand.rs
@@ -128,13 +128,11 @@ mod tests {
         let cloned2 = rng2.clone();
 
         assert_eq!(
-            &rng1,
-            &cloned1,
+            &rng1, &cloned1,
             "cloned rngs should match against the original"
         );
         assert_eq!(
-            &rng2,
-            &cloned2,
+            &rng2, &cloned2,
             "cloned rngs should match against the original"
         );
         assert_eq!(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -569,6 +569,40 @@ pub trait TurboRand: TurboCore + GenCore {
     }
 }
 
+/// Trait for enabling creating new [`TurboCore`] instances from an original instance.
+/// Similar to cloning, except forking modifies the state of the original instance in order
+/// to provide a new, random state for the forked instance. This allows for creating many randomised
+/// instances from a single seed in a deterministic manner.
+pub trait ForkableCore: TurboCore {
+    /// Forks a [`TurboCore`] instance by deterministically deriving a new instance based on the initial
+    /// seed.
+    ///
+    /// # Example
+    /// ```
+    /// use turborand::prelude::*;
+    ///
+    /// let rng1 = Rng::with_seed(Default::default());
+    /// let rng2 = Rng::with_seed(Default::default());
+    ///
+    /// // Use the RNGs once each.
+    /// rng1.bool();
+    /// rng2.bool();
+    ///
+    /// let forked1 = rng1.fork();
+    /// let forked2 = rng2.fork();
+    ///
+    /// // Forked instances should not be equal to the originals
+    /// assert_ne!(forked1, rng1);
+    /// assert_ne!(forked2, rng2);
+    /// // If they derived from the same initial seed, forked instances
+    /// // should be equal to each other...
+    /// assert_eq!(forked1, forked2);
+    /// // ...and thus yield the same outputs.
+    /// assert_eq!(forked1.u64(..), forked2.u64(..));
+    /// ```
+    fn fork(&self) -> Self;
+}
+
 impl<T: TurboCore + GenCore + ?Sized> TurboRand for T {}
 
 impl<T: TurboCore + ?Sized> TurboCore for Box<T> {


### PR DESCRIPTION
After reviewing the APIs, I decided to change cloning semantics of the RNGs so now cloning is more like a standard clone elsewhere. It is meant to duplicate an RNG instance in its entirety, internal state and all, so the original and the cloned instance are equivalent. The old cloning behaviour is now part of the `ForkableCore` trait, invoked with the `.fork()` method. Forking uses the original to generate a new seed for the forked instance, modifying the state of the original in order to deterministically create the new instance with a random state. This allows many random instances to be created from a single seed source, and those states will always be the same given one seed.

This is a breaking API change, therefore will necessitate a major version upgrade going forward.