### PR TITLE
feat(TurboRand): Implement _mut sampling methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turborand"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "Fast random number generators"


### PR DESCRIPTION
Provide `mut` versions of the sampling methods in `TurboRand` trait, basically.