### PR TITLE
perf(EntropyBuffer): Improve buffer on large or known slice sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turborand"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "Fast random number generators"

--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -23,6 +23,17 @@ fn turborand_cell_benchmark(c: &mut Criterion) {
             criterion::BatchSize::SmallInput,
         )
     });
+    c.bench_function("CellRng fill_bytes large", |b| {
+        let rand = Rng::default();
+
+        let data = [0u8; 2048];
+
+        b.iter_batched_ref(
+            || data,
+            |data| rand.fill_bytes(data),
+            criterion::BatchSize::LargeInput,
+        )
+    });
     c.bench_function("CellRng gen_u128", |b| {
         let rand = Rng::default();
         b.iter(|| black_box(rand.gen_u128()));
@@ -113,6 +124,17 @@ fn turborand_atomic_benchmark(c: &mut Criterion) {
             criterion::BatchSize::SmallInput,
         )
     });
+    c.bench_function("AtomicRng fill_bytes large", |b| {
+        let rand = AtomicRng::default();
+
+        let data = [0u8; 2048];
+
+        b.iter_batched_ref(
+            || data,
+            |data| rand.fill_bytes(data),
+            criterion::BatchSize::LargeInput,
+        )
+    });
     c.bench_function("AtomicRng gen_u128", |b| {
         let rand = AtomicRng::default();
         b.iter(|| black_box(rand.gen_u128()));
@@ -201,6 +223,17 @@ fn turborand_chacha_benchmark(c: &mut Criterion) {
             || data,
             |mut data| rand.fill_bytes(&mut data),
             criterion::BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("ChaChaRng fill_bytes large", |b| {
+        let rand = ChaChaRng::default();
+
+        let data = [0u8; 2048];
+
+        b.iter_batched_ref(
+            || data,
+            |data| rand.fill_bytes(data),
+            criterion::BatchSize::LargeInput,
         )
     });
     c.bench_function("ChaChaRng gen_u128", |b| {

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -213,6 +213,10 @@ mod tests {
         state.set(5);
 
         assert_eq!(state.get(), 5);
+
+        state.update(6);
+
+        assert_eq!(state.get(), 11);
     }
 
     #[test]
@@ -232,6 +236,10 @@ mod tests {
         state.set(5);
 
         assert_eq!(state.get(), 5);
+
+        state.update(6);
+
+        assert_eq!(state.get(), 11);
     }
 
     #[cfg(feature = "atomic")]


### PR DESCRIPTION
Improves `EntropyBuffer` throughput on large buffer sizes by being able to shortcircuit the caching process, or for slices of known size and avoid extra branches when there's still plenty of entropy available (such as with generating `u64` values).