### PR TITLE
fix(ChaChaRng): Field enum for deserialising

### DIFF
--- a/src/source/chacha.rs
+++ b/src/source/chacha.rs
@@ -139,6 +139,10 @@ impl<'de> Deserialize<'de> for ChaCha8 {
     {
         const FIELDS: &[&str] = &["state", "cache"];
 
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field { State, Cache }
+
         struct ChaChaVisitor;
 
         impl<'de> Visitor<'de> for ChaChaVisitor {
@@ -171,19 +175,18 @@ impl<'de> Deserialize<'de> for ChaCha8 {
 
                 while let Some(key) = map.next_key()? {
                     match key {
-                        "state" => {
+                        Field::State => {
                             if state.is_some() {
                                 return Err(serde::de::Error::duplicate_field("state"));
                             }
                             state = Some(map.next_value()?);
                         }
-                        "cache" => {
+                        Field::Cache => {
                             if cache.is_some() {
                                 return Err(serde::de::Error::duplicate_field("cache"));
                             }
                             cache = Some(map.next_value()?);
                         }
-                        other => return Err(serde::de::Error::unknown_field(other, FIELDS)),
                     }
                 }
 


### PR DESCRIPTION
Encountered a bug with some serialisation formats that mistake `&str` field keys as being a dynamic map type instead of set field names. As such, adding in an enum format for describing field names for custom Deserialization impl so that this restricts even further and allows deserialisation to be properly conducted by said finicky formats.

This fix does not change the serialised token output of `ChaChaRng`, so this won't be a breaking change.