### PR TITLE
feat(TurboRand): New sampling iterator methods

### DIFF
--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -98,6 +98,62 @@ fn turborand_cell_benchmark(c: &mut Criterion) {
         let rand = Rng::default();
         b.iter(|| black_box(rand.f32_normalized()));
     });
+    c.bench_function("CellRng sample", |b| {
+        let rand = Rng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample(&data)))
+    });
+    c.bench_function("CellRng sample one", |b| {
+        let rand = Rng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample(&data[0..1])))
+    });
+    c.bench_function("CellRng sample iter", |b| {
+        let rand = Rng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample_iter(data.iter())))
+    });
+    c.bench_function("CellRng sample iter one", |b| {
+        let rand = Rng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample_iter(data[0..1].iter())))
+    });
+    c.bench_function("CellRng weighted sample", |b| {
+        let rand = Rng::default();
+
+        let mut data = [0.0; 2048];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| black_box(rand.weighted_sample(&data, |(&item, _)| item)))
+    });
+    c.bench_function("CellRng weighted sample mut", |b| {
+        let rand = Rng::default();
+
+        let mut data = [0.0; 2048];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| {
+            let _ = rand.weighted_sample_mut(&mut data, |(&item, _)| item);
+        })
+    });
 }
 
 #[cfg(feature = "atomic")]
@@ -198,6 +254,62 @@ fn turborand_atomic_benchmark(c: &mut Criterion) {
     c.bench_function("AtomicRng f32 normalized", |b| {
         let rand = AtomicRng::default();
         b.iter(|| black_box(rand.f32_normalized()));
+    });
+    c.bench_function("AtomicRng sample", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample(&data)))
+    });
+    c.bench_function("AtomicRng sample one", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample(&data[0..1])))
+    });
+    c.bench_function("AtomicRng sample iter", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample_iter(data.iter())))
+    });
+    c.bench_function("AtomicRng sample iter one", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample_iter(data[0..1].iter())))
+    });
+    c.bench_function("AtomicRng weighted sample", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = [0.0; 2048];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| black_box(rand.weighted_sample(&data, |(&item, _)| item)))
+    });
+    c.bench_function("AtomicRng weighted sample mut", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = [0.0; 2048];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| {
+            let _ = rand.weighted_sample_mut(&mut data, |(&item, _)| item);
+        })
     });
 }
 
@@ -300,6 +412,62 @@ fn turborand_chacha_benchmark(c: &mut Criterion) {
     c.bench_function("ChaChaRng f32 normalized", |b| {
         let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.f32_normalized()));
+    });
+    c.bench_function("ChaChaRng sample", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample(&data)))
+    });
+    c.bench_function("ChaChaRng sample one", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample(&data[0..1])))
+    });
+    c.bench_function("ChaChaRng sample iter", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample_iter(data.iter())))
+    });
+    c.bench_function("ChaChaRng sample iter one", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = [0u8; 2048];
+
+        rand.fill_bytes(&mut data);
+
+        b.iter(|| black_box(rand.sample_iter(data[0..1].iter())))
+    });
+    c.bench_function("ChaChaRng weighted sample", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = [0.0; 2048];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| black_box(rand.weighted_sample(&data, |(&item, _)| item)))
+    });
+    c.bench_function("ChaChaRng weighted sample mut", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = [0.0; 2048];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| {
+            let _ = rand.weighted_sample_mut(&mut data, |(&item, _)| item);
+        })
     });
 }
 

--- a/src/chacha_rng.rs
+++ b/src/chacha_rng.rs
@@ -22,6 +22,7 @@ use crate::{Deserialize, Serialize};
 pub struct ChaChaRng(ChaCha8);
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl ChaChaRng {
     /// Creates a new [`ChaChaRng`] with a randomised seed.
     #[inline]
@@ -77,6 +78,7 @@ impl ForkableCore for ChaChaRng {
 impl SecureCore for ChaChaRng {}
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Default for ChaChaRng {
     /// Initialises a default instance of [`ChaChaRng`]. Warning, the default is
     /// seeded with a randomly generated state, so this is **not** deterministic.

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -13,6 +13,9 @@ use getrandom::{getrandom, Error};
 /// failure.
 #[inline]
 fn fallback_entropy<B: AsMut<[u8]>>(mut buffer: B) -> Result<(), Error> {
+    // If we reach this point, RandomState is unlikely to be random, as
+    // not even getrandom can yield valid entropy sources. So don't bother
+    // and instead find other means of generating entropy from available sources.
     let mut hasher = DefaultHasher::new();
     Instant::now().hash(&mut hasher);
     thread::current().id().hash(&mut hasher);

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -26,6 +26,7 @@ use crate::{Deserialize, Serialize};
 pub struct Rng(WyRand<CellState>);
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Rng {
     /// Creates a new [`Rng`] with a randomised seed.
     #[inline]
@@ -71,6 +72,7 @@ impl SeededCore for Rng {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Default for Rng {
     /// Initialises a default instance of [`Rng`]. Warning, the default is
     /// seeded with a randomly generated state, so this is **not** deterministic.
@@ -109,6 +111,7 @@ impl ForkableCore for Rng {
 pub struct AtomicRng(WyRand<AtomicState>);
 
 #[cfg(all(feature = "std", feature = "atomic"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl AtomicRng {
     /// Creates a new [`AtomicRng`] with a randomised seed.
     #[inline]
@@ -119,6 +122,7 @@ impl AtomicRng {
 }
 
 #[cfg(all(feature = "std", feature = "atomic"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Default for AtomicRng {
     /// Initialises a default instance of [`AtomicRng`]. Warning, the default is
     /// seeded with a randomly generated state, so this is **not** deterministic.

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,4 +1,4 @@
 #[cfg(feature = "chacha")]
-pub mod chacha;
+pub(crate) mod chacha;
 #[cfg(feature = "wyrand")]
-pub mod wyrand;
+pub(crate) mod wyrand;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -662,10 +662,13 @@ pub trait TurboRand: TurboCore + GenCore {
             len => loop {
                 let index = self.usize(0..len);
 
-                // SAFETY: Index already known to be within bounds, and the random
-                // usize will therefore always select an element within the bounds of
-                // the list.
-                if self.chance(weight_sampler((unsafe { list.get_unchecked(index) }, index))) {
+                if self.chance(weight_sampler((
+                    // SAFETY: Index already known to be within bounds, and the random
+                    // usize will therefore always select an element within the bounds of
+                    // the list.
+                    unsafe { list.get_unchecked(index) },
+                    index,
+                ))) {
                     // Get again in order to avoid borrowing restrictions within mut loops.
                     // SAFETY: Index already known to be within bounds, and the random
                     // usize will therefore always select an element within the bounds of

--- a/tests/smoke/mod.rs
+++ b/tests/smoke/mod.rs
@@ -722,7 +722,7 @@ fn weighted_sample_spread_testing() {
     let actual_histogram: BTreeMap<u32, _> = repeat_with(|| {
         // Select items from the array based on their value divided by the total sum to
         // form their weighting.
-        rng.weighted_sample(&samples, |&item| f64::from(item) / sample_total_weight)
+        rng.weighted_sample(&samples, |(&item, _)| f64::from(item) / sample_total_weight)
     })
     .take(1000)
     .flatten()

--- a/tests/smoke/mod.rs
+++ b/tests/smoke/mod.rs
@@ -640,6 +640,27 @@ fn sample_spread_testing() {
     );
 }
 
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn sample_iter_spread_testing() {
+    let rng = Rng::with_seed(Default::default());
+
+    let indexes: [usize; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+    let mut sampled = [0; 8];
+
+    for _ in 0..2000 {
+        let index = rng.sample_iter(indexes.iter()).unwrap();
+
+        sampled[*index] += 1;
+    }
+
+    assert_eq!(
+        &sampled,
+        &[214, 238, 267, 241, 237, 276, 261, 266],
+        "samples will occur across all array items at statistically equal chance"
+    );
+}
+
 #[cfg(feature = "alloc")]
 #[test]
 #[cfg(target_pointer_width = "64")]
@@ -659,7 +680,31 @@ fn sample_multiple_spread_testing() {
 
     assert_eq!(
         &sampled,
-        &[399, 369, 391, 377, 373, 384, 345, 362],
+        &[390, 364, 387, 359, 407, 377, 365, 351],
+        "samples will occur across all array items at statistically equal chance"
+    );
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn sample_multiple_iter_spread_testing() {
+    let rng = Rng::with_seed(Default::default());
+
+    let indexes: [usize; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+    let mut sampled = [0; 8];
+
+    for _ in 0..1000 {
+        let selected = rng.sample_multiple_iter(indexes.iter(), 3);
+
+        selected
+            .into_iter()
+            .for_each(|sample| sampled[*sample] += 1);
+    }
+
+    assert_eq!(
+        &sampled,
+        &[390, 364, 387, 359, 407, 377, 365, 351],
         "samples will occur across all array items at statistically equal chance"
     );
 }


### PR DESCRIPTION
Adds some sampling iterator methods, which take iterators instead of slices. Replaced the internals of `sample_multiple` methods with the iterator version as it is more efficient.