### PR TITLE
refactor(TurboRand): Use range for index method

### DIFF
--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -65,7 +65,7 @@ fn turborand_cell_benchmark(c: &mut Criterion) {
     c.bench_function("CellRng index", |b| {
         let rand = Rng::default();
         let bound = 20;
-        b.iter(|| black_box(rand.index(bound)));
+        b.iter(|| black_box(rand.index(..bound)));
     });
     c.bench_function("CellRng isize range", |b| {
         let rand = Rng::default();
@@ -227,7 +227,7 @@ fn turborand_atomic_benchmark(c: &mut Criterion) {
     c.bench_function("AtomicRng index", |b| {
         let rand = AtomicRng::default();
         let bound = 20;
-        b.iter(|| black_box(rand.index(bound)));
+        b.iter(|| black_box(rand.index(..bound)));
     });
     c.bench_function("AtomicRng isize range", |b| {
         let rand = AtomicRng::default();
@@ -390,7 +390,7 @@ fn turborand_chacha_benchmark(c: &mut Criterion) {
     c.bench_function("ChaChaRng index", |b| {
         let rand = ChaChaRng::default();
         let bound = 20;
-        b.iter(|| black_box(rand.index(bound)));
+        b.iter(|| black_box(rand.index(..bound)));
     });
     c.bench_function("ChaChaRng isize range", |b| {
         let rand = ChaChaRng::default();

--- a/tests/smoke/mod.rs
+++ b/tests/smoke/mod.rs
@@ -405,22 +405,22 @@ fn stable_indexing_smoke_testing() {
     let first = 128;
     let second = (u16::MAX as usize) + 128;
 
-    let index = rng.index(first);
+    let index = rng.index(..first);
 
     assert_eq!(&index, &102);
 
     for _ in 0..1000 {
-        let index = rng.index(first);
+        let index = rng.index(..first);
 
         assert!((..first).contains(&index));
     }
 
-    let index = rng.index(second);
+    let index = rng.index(..second);
 
     assert_eq!(&index, &47423);
 
     for _ in 0..1000 {
-        let index = rng.index(second);
+        let index = rng.index(..second);
 
         assert!((..second).contains(&index));
     }


### PR DESCRIPTION
Switch to using a range for `index` method, so that it matches the API of other integer methods.