### PR TITLE
feat(TurboRand): Optimise shuffle for different algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turborand"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "Fast random number generators"

--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -139,6 +139,33 @@ fn turborand_cell_benchmark(c: &mut Criterion) {
 
         b.iter(|| black_box(rand.sample_iter(data[0..1].iter())))
     });
+    c.bench_function("CellRng shuffle small", |b| {
+        let rand = Rng::default();
+
+        let mut data = [0.0; 8];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
+    });
+    c.bench_function("CellRng shuffle large", |b| {
+        let rand = Rng::default();
+
+        let mut data = vec![0.0; u16::MAX as usize];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
+    });
+    c.bench_function("CellRng shuffle xlarge", |b| {
+        let rand = Rng::default();
+
+        let mut data = vec![0.0; (u16::MAX as usize) * 10];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
+    });
     c.bench_function("CellRng weighted sample", |b| {
         let rand = Rng::default();
 
@@ -300,6 +327,33 @@ fn turborand_atomic_benchmark(c: &mut Criterion) {
         rand.fill_bytes(&mut data);
 
         b.iter(|| black_box(rand.sample_iter(data[0..1].iter())))
+    });
+    c.bench_function("AtomicRng shuffle small", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = [0.0; 8];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
+    });
+    c.bench_function("AtomicRng shuffle large", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = vec![0.0; u16::MAX as usize];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
+    });
+    c.bench_function("AtomicRng shuffle xlarge", |b| {
+        let rand = AtomicRng::default();
+
+        let mut data = vec![0.0; (u16::MAX as usize) * 10];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
     });
     c.bench_function("AtomicRng weighted sample", |b| {
         let rand = AtomicRng::default();
@@ -463,6 +517,33 @@ fn turborand_chacha_benchmark(c: &mut Criterion) {
         rand.fill_bytes(&mut data);
 
         b.iter(|| black_box(rand.sample_iter(data[0..1].iter())))
+    });
+    c.bench_function("ChaChaRng shuffle small", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = [0.0; 8];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
+    });
+    c.bench_function("ChaChaRng shuffle large", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = vec![0.0; u16::MAX as usize];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
+    });
+    c.bench_function("ChaChaRng shuffle xlarge", |b| {
+        let rand = ChaChaRng::default();
+
+        let mut data = vec![0.0; (u16::MAX as usize) * 10];
+
+        data.iter_mut().for_each(|slot| *slot = rand.f64());
+
+        b.iter(|| rand.shuffle(&mut data))
     });
     c.bench_function("ChaChaRng weighted sample", |b| {
         let rand = ChaChaRng::default();

--- a/src/chacha_rng.rs
+++ b/src/chacha_rng.rs
@@ -1,7 +1,7 @@
 //! A cryptographically secure PRNG (CSPRNG) based on [ChaCha8](https://cr.yp.to/chacha.html).
 use crate::{
     source::chacha::{utils::AlignedSeed, ChaCha8},
-    ForkableCore, GenCore, SecureCore, SeededCore, TurboCore,
+    ForkableCore, GenCore, SecureCore, SeededCore, TurboCore, TurboKind,
 };
 
 #[cfg(feature = "std")]
@@ -46,6 +46,8 @@ impl TurboCore for ChaChaRng {
 }
 
 impl GenCore for ChaChaRng {
+    const GEN_KIND: TurboKind = TurboKind::SLOW;
+
     #[inline]
     fn gen<const SIZE: usize>(&self) -> [u8; SIZE] {
         self.0.rand()
@@ -112,7 +114,7 @@ mod tests {
     fn no_leaking_debug() {
         let rng = ChaChaRng::with_seed([0u8; 40]);
 
-        assert_eq!(format!("{:?}", rng), "ChaChaRng(ChaCha8)");
+        assert_eq!(format!("{rng:?}"), "ChaChaRng(ChaCha8)");
     }
 
     #[cfg(feature = "serialize")]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -4,3 +4,5 @@ pub(crate) mod buffer;
 
 #[cfg(feature = "wyrand")]
 pub(crate) mod state;
+
+pub(crate) mod uniform;

--- a/src/internal/uniform.rs
+++ b/src/internal/uniform.rs
@@ -1,0 +1,121 @@
+use crate::TurboRand;
+
+/// Similar to a Uniform distribution, after returning a number in the range [0,n], n is increased by 1.
+/// Adapted from https://github.com/rust-random/rand/blob/master/src/seq/increasing_uniform.rs.
+pub(crate) struct IncreasingUniformIter<R: TurboRand> {
+    rng: R,
+    n: u64,
+    // Chunk is a random number in [0, (n + 1) * (n + 2) *..* (n + chunk_remaining) )
+    chunk: u64,
+    chunk_remaining: u8,
+    len: usize,
+}
+
+impl<R: TurboRand> IncreasingUniformIter<R> {
+    /// Create a dice roller.
+    /// The next item returned will be a random number in the range [0,n]
+    #[inline]
+    pub(crate) fn new(rng: R, n: u64, len: usize) -> Self {
+        // If n = 0, the first number returned will always be 0
+        // so we don't need to generate a random number
+        let chunk_remaining = u8::from(n == 0);
+
+        Self {
+            rng,
+            n,
+            chunk: 0,
+            chunk_remaining,
+            len,
+        }
+    }
+
+    /// Returns a number in [0,n] and increments n by 1.
+    /// Generates new random bits as needed
+    /// Panics if `n >= u64::MAX`
+    #[inline]
+    fn next_swap_index(&mut self) -> usize {
+        let next_n = self.n + 1;
+
+        let next_chunk_remaining = self.chunk_remaining.checked_sub(1).unwrap_or_else(|| {
+            // If the chunk is empty, generate a new chunk
+            let (bound, remaining) = calculate_bound_u64(next_n);
+            // bound = (n + 1) * (n + 2) *..* (n + remaining)
+            self.chunk = self.rng.u64(..bound);
+            // Chunk is a random number in
+            // [0, (n + 1) * (n + 2) *..* (n + remaining) )
+            remaining - 1
+        });
+
+        let result = if next_chunk_remaining == 0 {
+            // `chunk` is a random number in the range [0..n+1)
+            // Because `chunk_remaining` is about to be set to zero
+            // we do not need to clear the chunk here
+            self.chunk as usize
+        } else {
+            // `chunk` is a random number in a range that is a multiple of n+1
+            // so r will be a random number in [0..n+1)
+            let random = self.chunk % next_n;
+            self.chunk /= next_n;
+            random as usize
+        };
+
+        self.chunk_remaining = next_chunk_remaining;
+        self.n = next_n;
+        result
+    }
+}
+
+impl<R: TurboRand> Iterator for IncreasingUniformIter<R> {
+    type Item = (usize, usize);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len == (self.n as usize) {
+            None
+        } else {
+            Some((self.n as usize, self.next_swap_index()))
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len - self.n as usize;
+        (len, Some(len))
+    }
+}
+
+impl<R: TurboRand> ExactSizeIterator for IncreasingUniformIter<R> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.size_hint().0
+    }
+}
+
+#[inline]
+/// Calculates `bound`, `count` such that bound (m)*(m+1)*..*(m + remaining - 1)
+fn calculate_bound_u64(min: u64) -> (u64, u8) {
+    debug_assert!(min > 1);
+
+    #[inline]
+    const fn inner(min: u64) -> (u64, u8) {
+        let mut product = min;
+        let mut current = min + 1;
+
+        while let Some(p) = product.checked_mul(current) {
+            product = p;
+            current += 1;
+        }
+
+        let count = (current - min) as u8;
+        (product, count)
+    }
+
+    const RESULT2: (u64, u8) = inner(2);
+
+    match min {
+        // Making this value a constant instead of recalculating it
+        // gives a significant (~50%) performance boost for small shuffles
+        2 => RESULT2,
+        min => inner(min),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,6 @@ pub mod rng;
 mod source;
 mod traits;
 
-pub use traits::{ForkableCore, GenCore, SecureCore, SeededCore, TurboCore, TurboRand};
+pub use traits::{ForkableCore, GenCore, SecureCore, SeededCore, TurboCore, TurboKind, TurboRand};
 
 pub mod prelude;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     internal::state::CellState, source::wyrand::WyRand, ForkableCore, GenCore, SeededCore,
-    TurboCore,
+    TurboCore, TurboKind,
 };
 
 #[cfg(feature = "std")]
@@ -50,6 +50,8 @@ impl TurboCore for Rng {
 }
 
 impl GenCore for Rng {
+    const GEN_KIND: TurboKind = TurboKind::FAST;
+
     #[inline]
     fn gen<const SIZE: usize>(&self) -> [u8; SIZE] {
         self.0.rand()
@@ -187,6 +189,8 @@ impl TurboCore for AtomicRng {
 
 #[cfg(feature = "atomic")]
 impl GenCore for AtomicRng {
+    const GEN_KIND: TurboKind = TurboKind::FAST;
+
     #[inline]
     fn gen<const SIZE: usize>(&self) -> [u8; SIZE] {
         self.0.rand()
@@ -228,7 +232,7 @@ mod tests {
     fn rng_no_leaking_debug() {
         let rng = Rng::with_seed(Default::default());
 
-        assert_eq!(format!("{:?}", rng), "Rng(WyRand(CellState))");
+        assert_eq!(format!("{rng:?}"), "Rng(WyRand(CellState))");
     }
 
     #[cfg(all(feature = "fmt", feature = "atomic"))]
@@ -236,7 +240,7 @@ mod tests {
     fn atomic_no_leaking_debug() {
         let rng = AtomicRng::with_seed(Default::default());
 
-        assert_eq!(format!("{:?}", rng), "AtomicRng(WyRand(AtomicState))");
+        assert_eq!(format!("{rng:?}"), "AtomicRng(WyRand(AtomicState))");
     }
 
     #[cfg(feature = "rand")]
@@ -258,8 +262,7 @@ mod tests {
 
         assert_eq!(
             result, 14_839_104_130_206_199_084,
-            "Should receive expect random u64 output, got {} instead",
-            result
+            "Should receive expect random u64 output, got {result} instead",
         );
 
         let mut rng = Rng::with_seed(Default::default());
@@ -270,8 +273,7 @@ mod tests {
 
         assert_eq!(
             result, 14_839_104_130_206_199_084,
-            "Should receive expect random u64 output, got {} instead",
-            result
+            "Should receive expect random u64 output, got {result} instead",
         );
     }
 

--- a/src/source/chacha.rs
+++ b/src/source/chacha.rs
@@ -144,7 +144,7 @@ impl ChaCha8 {
 impl Clone for ChaCha8 {
     fn clone(&self) -> Self {
         Self {
-            state: UnsafeCell::new(self.get_state().clone()),
+            state: UnsafeCell::new(*self.get_state()),
             cache: self.cache.clone(),
         }
     }
@@ -280,7 +280,7 @@ mod tests {
     fn no_leaking_debug() {
         let source = ChaCha8::with_seed([0u8; 40].into());
 
-        assert_eq!(format!("{:?}", source), "ChaCha8");
+        assert_eq!(format!("{source:?}"), "ChaCha8");
     }
 
     #[test]

--- a/src/source/wyrand.rs
+++ b/src/source/wyrand.rs
@@ -147,6 +147,6 @@ mod tests {
     fn no_leaking_debug() {
         let rng = WyRand::<CellState>::with_seed(Default::default());
 
-        assert_eq!(format!("{:?}", rng), "WyRand(CellState)");
+        assert_eq!(format!("{rng:?}"), "WyRand(CellState)");
     }
 }

--- a/tests/smoke/mod.rs
+++ b/tests/smoke/mod.rs
@@ -7,23 +7,23 @@ fn range_determinism_testing() {
 
     let value = rng.u64(1..10);
 
-    assert_eq!(value, 8, "Not the same expected value: got {}", value);
+    assert_eq!(value, 8, "Not the same expected value: got {value}");
 
     let value = rng.u32(1..10);
 
-    assert_eq!(value, 2, "Not the same expected value: got {}", value);
+    assert_eq!(value, 2, "Not the same expected value: got {value}");
 
     let value = rng.u16(1..10);
 
-    assert_eq!(value, 9, "Not the same expected value: got {}", value);
+    assert_eq!(value, 9, "Not the same expected value: got {value}");
 
     let value = rng.u8(1..10);
 
-    assert_eq!(value, 5, "Not the same expected value: got {}", value);
+    assert_eq!(value, 5, "Not the same expected value: got {value}");
 
     let value = rng.bool();
 
-    assert!(value, "Not the expect boolean: got {}", value);
+    assert!(value, "Not the expect boolean: got {value}");
 }
 
 #[cfg(feature = "std")]
@@ -37,8 +37,7 @@ fn range_smoke_testing() {
 
         assert!(
             (4..10).contains(&index),
-            "Must generate a number within 4 and 10, received: {}",
-            index
+            "Must generate a number within 4 and 10, received: {index}",
         );
     }
 
@@ -47,8 +46,7 @@ fn range_smoke_testing() {
 
         assert!(
             (..20).contains(&index),
-            "Must generate a number within 0 and 20, received: {}",
-            index
+            "Must generate a number within 0 and 20, received: {index}",
         );
     }
 
@@ -57,8 +55,7 @@ fn range_smoke_testing() {
 
         assert!(
             (4..=15).contains(&index),
-            "Must generate a number within 4 and inclusively 15, received: {}",
-            index
+            "Must generate a number within 4 and inclusively 15, received: {index}",
         );
     }
 
@@ -67,28 +64,25 @@ fn range_smoke_testing() {
 
         assert!(
             (-10..10).contains(&index),
-            "Must generate a number within -10 and 10, received: {}",
-            index
+            "Must generate a number within -10 and 10, received: {index}",
         );
     }
 
     for _ in 0..1000 {
-        let value = rng.u128(6..61);
+        let index = rng.u128(6..61);
 
         assert!(
-            (6..61).contains(&value),
-            "Must generate a number within 6 and 61, received: {}",
-            value
+            (6..61).contains(&index),
+            "Must generate a number within 6 and 61, received: {index}",
         );
     }
 
     for _ in 0..1000 {
-        let value = rng.i128(-20..20);
+        let index = rng.i128(-20..20);
 
         assert!(
-            (-20..20).contains(&value),
-            "Must generate a number within -20 and 20, received: {}",
-            value
+            (-20..20).contains(&index),
+            "Must generate a number within -20 and 20, received: {index}",
         );
     }
 }
@@ -104,8 +98,7 @@ fn float_smoke_testing() {
 
         assert!(
             (0.0..=1.0).contains(&index),
-            "Must generate a number within 0.0 and 1.0, received: {}",
-            index
+            "Must generate a number within 0.0 and 1.0, received: {index}",
         );
     }
 
@@ -114,8 +107,7 @@ fn float_smoke_testing() {
 
         assert!(
             (-1.0..=1.0).contains(&index),
-            "Must generate a number within -1.0 and 1.0, received: {}",
-            index
+            "Must generate a number within -1.0 and 1.0, received: {index}",
         );
     }
 
@@ -124,8 +116,7 @@ fn float_smoke_testing() {
 
         assert!(
             (0.0..=1.0).contains(&index),
-            "Must generate a number within 0.0 and 1.0, received: {}",
-            index
+            "Must generate a number within 0.0 and 1.0, received: {index}",
         );
     }
 
@@ -134,8 +125,7 @@ fn float_smoke_testing() {
 
         assert!(
             (-1.0..=1.0).contains(&index),
-            "Must generate a number within -1.0 and 1.0, received: {}",
-            index
+            "Must generate a number within -1.0 and 1.0, received: {index}",
         );
     }
 }
@@ -437,8 +427,7 @@ fn character_smoke_testing() {
 
         assert!(
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".contains(character),
-            "Must output an alphabetic character within range, received '{}'",
-            character
+            "Must output an alphabetic character within range, received '{character}'",
         );
     }
 
@@ -447,8 +436,7 @@ fn character_smoke_testing() {
 
         assert!(
             "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".contains(character),
-            "Must output an alphanumeric character within range, received '{}'",
-            character
+            "Must output an alphanumeric character within range, received '{character}'",
         );
     }
 
@@ -457,8 +445,7 @@ fn character_smoke_testing() {
 
         assert!(
             "abcdefghijklmnopqrstuvwxyz".contains(character),
-            "Must output a lowercase character within range, received '{}'",
-            character
+            "Must output a lowercase character within range, received '{character}'",
         );
     }
 
@@ -467,8 +454,7 @@ fn character_smoke_testing() {
 
         assert!(
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ".contains(character),
-            "Must output an uppercase character within range, received '{}'",
-            character
+            "Must output an uppercase character within range, received '{character}'",
         );
     }
 }
@@ -484,8 +470,7 @@ fn digit_smoke_testing() {
 
         assert!(
             "0123456789".contains(digit),
-            "Must output a digit within radix, received '{}'",
-            digit
+            "Must output a digit within radix, received '{digit}'",
         );
     }
 
@@ -494,8 +479,7 @@ fn digit_smoke_testing() {
 
         assert!(
             "01".contains(digit),
-            "Must output a digit within radix, received '{}'",
-            digit
+            "Must output a digit within radix, received '{digit}'",
         );
     }
 
@@ -504,8 +488,7 @@ fn digit_smoke_testing() {
 
         assert!(
             "01234567".contains(digit),
-            "Must output a digit within radix, received '{}'",
-            digit
+            "Must output a digit within radix, received '{digit}'",
         );
     }
 
@@ -514,8 +497,7 @@ fn digit_smoke_testing() {
 
         assert!(
             "0123456789abcdef".contains(digit),
-            "Must output a digit within radix, received '{}'",
-            digit
+            "Must output a digit within radix, received '{digit}'",
         );
     }
 
@@ -524,8 +506,7 @@ fn digit_smoke_testing() {
 
         assert!(
             "0123456789abcdefghijklmnopqrstuvwxyz".contains(digit),
-            "Must output a digit within radix, received '{}'",
-            digit
+            "Must output a digit within radix, received '{digit}'",
         );
     }
 }
@@ -586,7 +567,7 @@ fn chacha_rng_smoke_test() {
     }
 }
 
-#[cfg(feature = "chacha")]
+#[cfg(all(feature = "chacha", feature = "alloc"))]
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn chacha_rng_spread_test() {
@@ -782,9 +763,97 @@ fn shuffle_smoke_testing() {
 
     let mut values = [1, 2, 3, 4, 5, 6];
 
-    repeat_with(|| &rng)
-        .take(100)
-        .for_each(|r| r.shuffle(&mut values));
+    for _ in 0..100 {
+        rng.shuffle(&mut values);
+    }
 
     assert_eq!(&values, &[2, 5, 3, 1, 6, 4]);
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn shuffle_spread_testing() {
+    let rng = Rng::with_seed(Default::default());
+
+    let mut values: [u32; 6] = [0, 1, 2, 3, 4, 5];
+
+    let actual_histogram: BTreeMap<usize, _> = repeat_with(|| {
+        // Shuffle the values then copy the list
+        rng.shuffle(&mut values);
+
+        values
+    })
+    .take(1000)
+    .fold(BTreeMap::new(), |mut histogram, res| {
+        let index = res
+            .iter()
+            .enumerate()
+            .find(|(_, &num)| num == 0)
+            .map(|(index, _)| index)
+            .unwrap();
+
+        *histogram.entry(index).or_default() += 1;
+
+        histogram
+    });
+
+    // Expected indexes tracking where the value 0 ends up at after being shuffled.
+    let expected_histogram = BTreeMap::from_iter(vec![
+        (0, 183),
+        (1, 168),
+        (2, 139),
+        (3, 188),
+        (4, 173),
+        (5, 149),
+    ]);
+
+    assert_eq!(
+        actual_histogram, expected_histogram,
+        "shuffled value positions should match in frequency to the expected histogram"
+    );
+}
+
+#[cfg(all(feature = "chacha", feature = "alloc"))]
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn chacha_shuffle_spread_testing() {
+    let rng = ChaChaRng::with_seed([0; 40]);
+
+    let mut values: [u32; 6] = [0, 1, 2, 3, 4, 5];
+
+    let actual_histogram: BTreeMap<usize, _> = repeat_with(|| {
+        // Shuffle the values then copy the list
+        rng.shuffle(&mut values);
+
+        values
+    })
+    .take(1000)
+    .fold(BTreeMap::new(), |mut histogram, res| {
+        let index = res
+            .iter()
+            .enumerate()
+            .find(|(_, &num)| num == 0)
+            .map(|(index, _)| index)
+            .unwrap();
+
+        *histogram.entry(index).or_default() += 1;
+
+        histogram
+    });
+
+    // Expected indexes tracking where the value 0 ends up at after being shuffled.
+    let expected_histogram = BTreeMap::from_iter(vec![
+        (0, 166),
+        (1, 163),
+        (2, 161),
+        (3, 184),
+        (4, 169),
+        (5, 157),
+    ]);
+
+    assert_eq!(
+        actual_histogram, expected_histogram,
+        "shuffled value positions should match in frequency to the expected histogram"
+    );
 }


### PR DESCRIPTION
Enabling shuffling performance improvements for algorithms that benefit from it. Creates a breaking API change for `GenCore` as there's a need to store an associated constant, but the benefit from it is being able to switch between different shuffling algorithms to match the PRNG's perf profile where it makes sense. Wyrand does not benefit from an Increasing Uniform sampler, as it is simply less expensive to generate a new index straight from the PRNG itself, whereas ChaCha8 benefits from the new sampler impl.

Also included are clippy fixes, because new rustc version.