### PR TITLE
refactor(TurboRand): Tidied char impl with from_32 method

### DIFF
--- a/benches/rand_bench.rs
+++ b/benches/rand_bench.rs
@@ -103,6 +103,10 @@ fn turborand_cell_benchmark(c: &mut Criterion) {
         let rand = Rng::default();
         b.iter(|| black_box(rand.f32_normalized()));
     });
+    c.bench_function("CellRng char", |b| {
+        let rand = Rng::default();
+        b.iter(|| black_box(rand.char('a'..='Ç')));
+    });
     c.bench_function("CellRng sample", |b| {
         let rand = Rng::default();
 
@@ -291,6 +295,10 @@ fn turborand_atomic_benchmark(c: &mut Criterion) {
     c.bench_function("AtomicRng f32 normalized", |b| {
         let rand = AtomicRng::default();
         b.iter(|| black_box(rand.f32_normalized()));
+    });
+    c.bench_function("AtomicRng char", |b| {
+        let rand = AtomicRng::default();
+        b.iter(|| black_box(rand.char('a'..='Ç')));
     });
     c.bench_function("AtomicRng sample", |b| {
         let rand = AtomicRng::default();
@@ -481,6 +489,10 @@ fn turborand_chacha_benchmark(c: &mut Criterion) {
     c.bench_function("ChaChaRng f32 normalized", |b| {
         let rand = ChaChaRng::default();
         b.iter(|| black_box(rand.f32_normalized()));
+    });
+    c.bench_function("ChaChaRng char", |b| {
+        let rand = ChaChaRng::default();
+        b.iter(|| black_box(rand.char('a'..='Ç')));
     });
     c.bench_function("ChaChaRng sample", |b| {
         let rand = ChaChaRng::default();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -868,8 +868,7 @@ pub trait TurboRand: TurboCore + GenCore {
                 } else {
                     x as u32 + 1
                 };
-                char::try_from(scalar)
-                    .unwrap_or_else(|_| panic!("Invalid exclusive lower character bound"))
+                char::from_u32(scalar).expect("Invalid exclusive lower character bound")
             }
         };
 
@@ -882,8 +881,7 @@ pub trait TurboRand: TurboCore + GenCore {
                 } else {
                     (x as u32).wrapping_sub(1)
                 };
-                char::try_from(scalar)
-                    .unwrap_or_else(|_| panic!("Invalid exclusive upper character bound"))
+                char::from_u32(scalar).expect("Invalid exclusive upper character bound")
             }
         };
 
@@ -898,14 +896,14 @@ pub trait TurboRand: TurboCore + GenCore {
             0
         };
 
-        let range = upper_scalar - lower_scalar - gap;
-        let mut val = self.u32(0..=range) + lower_scalar;
+        let range = upper_scalar - gap;
+        let mut val = self.u32(lower_scalar..=range);
 
         if val >= SURROGATE_START {
             val += gap;
         }
 
-        val.try_into().unwrap()
+        char::from_u32(val).unwrap()
     }
 }
 

--- a/tests/char_battery/mod.rs
+++ b/tests/char_battery/mod.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use std::{collections::HashSet, convert::TryFrom, ops::RangeBounds};
+use std::{collections::HashSet, ops::RangeBounds};
 
 fn char_coverage_stress_test<R>(n: usize, range: R)
 where
@@ -30,14 +30,14 @@ fn char_battery_tests() {
     let stx = 2u8 as char;
     // Some undefined Hangul Jamo codepoints just before
     // the surrogate area.
-    let last_jamo = char::try_from(0xd7ffu32).unwrap();
-    let penultimate_jamo = char::try_from(last_jamo as u32 - 1).unwrap();
+    let last_jamo = char::from_u32(0xd7ffu32).unwrap();
+    let penultimate_jamo = char::from_u32(last_jamo as u32 - 1).unwrap();
     // Private-use codepoints just after the surrogate area.
-    let first_private = char::try_from(0xe000u32).unwrap();
-    let second_private = char::try_from(first_private as u32 + 1).unwrap();
+    let first_private = char::from_u32(0xe000u32).unwrap();
+    let second_private = char::from_u32(first_private as u32 + 1).unwrap();
     // Private-use codepoints at the end of Unicode space.
     let last_private = char::MAX;
-    let penultimate_private = char::try_from(last_private as u32 - 1).unwrap();
+    let penultimate_private = char::from_u32(last_private as u32 - 1).unwrap();
 
     char_coverage_stress_test(100, nul..stx);
     char_coverage_stress_test(100, nul..=soh);


### PR DESCRIPTION
Minor refactoring to make use of `from_u32` instead of `try_from` and other small clean-ups.